### PR TITLE
Bugfixes - Video Capture for A4.3 && Aync IO

### DIFF
--- a/src/android/Capture.java
+++ b/src/android/Capture.java
@@ -245,10 +245,6 @@ public class Capture extends CordovaPlugin {
             intent.putExtra("android.intent.extra.durationLimit", duration);
         }
         
-        // Specify file so that large image is captured and returned
-        File movie = new File(getTempDirectoryPath(), "Capture.avi");
-        intent.putExtra(android.provider.MediaStore.EXTRA_OUTPUT, Uri.fromFile(movie));
-        
         this.cordova.startActivityForResult((CordovaPlugin) this, intent, CAPTURE_VIDEO);
     }
 
@@ -330,8 +326,20 @@ public class Capture extends CordovaPlugin {
                     this.fail(createErrorObject(CAPTURE_INTERNAL_ERR, "Error capturing image."));
                 }
             } else if (requestCode == CAPTURE_VIDEO) {
-                // Get the uri of the video clip
-                Uri data = intent.getData();
+                
+                Uri data = null;
+                if (intent != null)
+                {
+                    // Get the uri of the video clip
+                    data = intent.getData();
+                }
+
+                if (data == null)
+                {
+                    File movie = new File(getTempDirectoryPath(), "Capture.avi");
+                    data = Uri.fromFile(movie);            			
+                }
+                
                 // create a file object from the uri
                 if(data == null)
                 {


### PR DESCRIPTION
1) MediaStore.ACTION_VIDEO_CAPTURE Uri return value is null in 4.3  -
http://code.google.com/p/android/issues/detail?id=57996
2) Async IO -
http://stackoverflow.com/questions/19183174/phonegap-video-capture-crashes
