### PR TITLE
CB-5202 fix from lubogospod

### DIFF
--- a/src/android/Capture.java
+++ b/src/android/Capture.java
@@ -346,8 +346,19 @@ public class Capture extends CordovaPlugin {
 
                     @Override
                     public void run() {
-                        // Get the uri of the video clip
-                        Uri data = intent.getData();
+                    
+                        Uri data = null;
+                        
+                        if (intent != null){
+                            // Get the uri of the video clip
+                            data = intent.getData();
+                        }
+                        
+                        if( data == null){
+                           File movie = new File(getTempDirectoryPath(), "Capture.avi");
+                           data = Uri.fromFile(movie);
+                        }
+                        
                         // create a file object from the uri
                         if(data == null)
                         {
@@ -428,7 +439,6 @@ public class Capture extends CordovaPlugin {
             // this will never happen
             e.printStackTrace();
         }
-
         return obj;
     }
 


### PR DESCRIPTION
I think that https://github.com/apache/cordova-plugin-media-capture/pull/8 was closed prematurely. This fix is needed for Video record on Nexus 4.3 devices. I don't think lubogospod needs a CLA since this is pretty much just null fencing. 
