### PR TITLE
CB-6852 media-capture plugin has wrong URIs for AudioRecorder.xaml and VideoRecorder.xaml on WP

### DIFF
--- a/src/wp/UI/AudioCaptureTask.cs
+++ b/src/wp/UI/AudioCaptureTask.cs
@@ -76,7 +76,7 @@ namespace WPCordovaClassLib.Cordova.UI
 
                 string baseUrl = "/";
                 // dummy parameter is used to always open a fresh version
-                root.Navigate(new System.Uri(baseUrl + "Plugins/org.apache.cordova.core.media-capture/AudioRecorder.xaml?dummy=" + Guid.NewGuid().ToString(), UriKind.Relative));
+                root.Navigate(new System.Uri(baseUrl + "Plugins/org.apache.cordova.media-capture/AudioRecorder.xaml?dummy=" + Guid.NewGuid().ToString(), UriKind.Relative));
 
             });
         }

--- a/src/wp/UI/VideoCaptureTask.cs
+++ b/src/wp/UI/VideoCaptureTask.cs
@@ -76,7 +76,7 @@ namespace WPCordovaClassLib.Cordova.UI
 
                 string baseUrl = "/";
                 // dummy parameter is used to always open a fresh version
-                root.Navigate(new System.Uri(baseUrl + "Plugins/org.apache.cordova.core.media-capture/VideoRecorder.xaml?dummy=" + Guid.NewGuid().ToString(), UriKind.Relative));
+                root.Navigate(new System.Uri(baseUrl + "Plugins/org.apache.cordova.media-capture/VideoRecorder.xaml?dummy=" + Guid.NewGuid().ToString(), UriKind.Relative));
             });
         }
 


### PR DESCRIPTION
Fix for [CB-6852](https://issues.apache.org/jira/browse/CB-6852)
