### PR TITLE
fix(android): Write the recorded files to external storage directory, and pass in EXTRA_OUTPUT so the files can be read after onActivityResult is called

### DIFF
--- a/src/android/Capture.java
+++ b/src/android/Capture.java
@@ -206,7 +206,7 @@ public class Capture extends CordovaPlugin {
     }
 
     private String getTempDirectoryPath() {
-        return Environment.getExternalStorageDirectory().getAbsolutePath()
+        return Environment.getExternalStorageDirectory().getAbsolutePath();
     }
 
     /**


### PR DESCRIPTION
The original temporary cache directory is not readable since you cannot do playback what you just recorded in the camera app. Likewise causing the path not available after the the activity result has been called.

By changing the path to external storage directory and passing the EXTRA_OUTPUT options, it allows the file at data uri still able to be read.
