### PR TITLE
iOS: Allow video quality to be specified in CaptureVideoOptions

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -333,6 +333,8 @@ capturing a video clip, the `CaptureErrorCB` callback executes with a
 
 - __duration__: The maximum duration of a video clip, in seconds.
 
+- __quality__: Integer in the range 0-100 indicating the quality to capture video in, 100 being highest possible quality. Currently only supported for iOS.
+
 ### Example
 
     // limit capture operation to 3 video clips

--- a/src/ios/CDVCapture.m
+++ b/src/ios/CDVCapture.m
@@ -227,6 +227,7 @@
     // taking more than one video (limit) is only supported if provide own controls via cameraOverlayView property
     NSNumber* duration = [options objectForKey:@"duration"];
     NSString* mediaType = nil;
+    NSNumber* quality = [options objectForKey:@"quality"];
 
     if ([UIImagePickerController isSourceTypeAvailable:UIImagePickerControllerSourceTypeCamera]) {
         // there is a camera, it is available, make sure it can do movies
@@ -254,6 +255,18 @@
         pickerController.delegate = self;
         pickerController.sourceType = UIImagePickerControllerSourceTypeCamera;
         pickerController.allowsEditing = NO;
+
+        // Set quality of captured video
+        if (quality) {
+            if ([quality intValue] < 33) {
+                pickerController.videoQuality = UIImagePickerControllerQualityTypeLow;
+            } else if ([quality intValue] < 66) {
+                pickerController.videoQuality = UIImagePickerControllerQualityTypeMedium;
+            } else {
+                pickerController.videoQuality = UIImagePickerControllerQualityTypeHigh;
+            }
+        }
+
         // iOS 3.0
         pickerController.mediaTypes = [NSArray arrayWithObjects:mediaType, nil];
 

--- a/www/CaptureVideoOptions.js
+++ b/www/CaptureVideoOptions.js
@@ -27,6 +27,8 @@ var CaptureVideoOptions = function(){
     this.limit = 1;
     // Maximum duration of a single video clip in seconds.
     this.duration = 0;
+    // Integer in the range 0-100 specifiying quality of captured video
+    this.quality = 50;
 };
 
 module.exports = CaptureVideoOptions;


### PR DESCRIPTION
Implements a new property in CaptureVideoOptions which allows for specifying the quality of captured video as an integer in the range 0-100 with 100 being the highest possible quality.
The specified value is translated into one of the following `UIImagePickerControllerQualityType` constants ([see Apple docs](https://developer.apple.com/library/ios/documentation/UIKit/Reference/UIImagePickerController_Class/#//apple_ref/c/tdef/UIImagePickerControllerQualityType)):
0-32: `UIImagePickerControllerQualityTypeLow`
33-65: `UIImagePickerControllerQualityTypeMedium`
66-100: `UIImagePickerControllerQualityTypeHigh`
