### PR TITLE
CB-8687 consolidate manifest targets

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -214,18 +214,8 @@ xmlns:rim="http://www.blackberry.com/ns/widgets"
 
     <!-- windows -->
     <platform name="windows">
-        
-        <config-file target="package.phone.appxmanifest" parent="/Package/Capabilities">
-            <DeviceCapability Name="microphone" />
-            <DeviceCapability Name="webcam" />
-        </config-file>
-        
-        <config-file target="package.windows.appxmanifest" parent="/Package/Capabilities">
-            <DeviceCapability Name="microphone" />
-            <DeviceCapability Name="webcam" />
-        </config-file>
-        
-        <config-file target="package.windows80.appxmanifest" parent="/Package/Capabilities">
+
+        <config-file target="package.appxmanifest" parent="/Package/Capabilities">
             <DeviceCapability Name="microphone" />
             <DeviceCapability Name="webcam" />
         </config-file>


### PR DESCRIPTION
Target manifests are listed for phone, windows and windows80 separately. Consolidate them and use a single package.appxmanifest target. 