### PR TITLE
Cancel of Image Capture Causes App to Crash.

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "cordova-windows"
   ],
   "peerDependencies": {
-    
+    "cordova-plugin-file": ">=2.0.0"
   },
   "author": "Apache Software Foundation",
   "license": "Apache 2.0"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "cordova-windows"
   ],
   "peerDependencies": {
-    "cordova-plugin-file": ">=2.0.0"
+    
   },
   "author": "Apache Software Foundation",
   "license": "Apache 2.0"

--- a/plugin.xml
+++ b/plugin.xml
@@ -30,7 +30,9 @@ xmlns:rim="http://www.blackberry.com/ns/widgets"
     <keywords>cordova,media,capture</keywords>
     <repo>https://git-wip-us.apache.org/repos/asf/cordova-plugin-media-capture.git</repo>
     <issue>https://issues.apache.org/jira/browse/CB/component/12320646</issue>
-    
+
+    <dependency id="cordova-plugin-file" version=">=2.0.0" />
+
     <js-module src="www/CaptureAudioOptions.js" name="CaptureAudioOptions">
         <clobbers target="CaptureAudioOptions" />
     </js-module>

--- a/plugin.xml
+++ b/plugin.xml
@@ -31,8 +31,6 @@ xmlns:rim="http://www.blackberry.com/ns/widgets"
     <repo>https://git-wip-us.apache.org/repos/asf/cordova-plugin-media-capture.git</repo>
     <issue>https://issues.apache.org/jira/browse/CB/component/12320646</issue>
     
-    <dependency id="cordova-plugin-file" version=">=2.0.0" />
-
     <js-module src="www/CaptureAudioOptions.js" name="CaptureAudioOptions">
         <clobbers target="CaptureAudioOptions" />
     </js-module>

--- a/src/windows/CaptureProxy.js
+++ b/src/windows/CaptureProxy.js
@@ -375,17 +375,21 @@ module.exports = {
             cameraCaptureUI.photoSettings.maxResolution = Windows.Media.Capture.CameraCaptureUIMaxPhotoResolution.highestAvailable;
             cameraCaptureUI.photoSettings.format = Windows.Media.Capture.CameraCaptureUIPhotoFormat.jpeg;
             cameraCaptureUI.captureFileAsync(Windows.Media.Capture.CameraCaptureUIMode.photo).done(function (file) {
-                file.moveAsync(Windows.Storage.ApplicationData.current.localFolder, "cameraCaptureImage.jpg", Windows.Storage.NameCollisionOption.generateUniqueName).then(function () {
-                    file.getBasicPropertiesAsync().then(function (basicProperties) {
-                        var result = new MediaFile(file.name, 'ms-appdata:///local/' + file.name, file.contentType, basicProperties.dateModified, basicProperties.size);
-                        result.fullPath = file.path;
-                        successCallback([result]);
+                if (file) {
+                    file.moveAsync(Windows.Storage.ApplicationData.current.localFolder, "cameraCaptureImage.jpg", Windows.Storage.NameCollisionOption.generateUniqueName).then(function () {
+                        file.getBasicPropertiesAsync().then(function (basicProperties) {
+                            var result = new MediaFile(file.name, 'ms-appdata:///local/' + file.name, file.contentType, basicProperties.dateModified, basicProperties.size);
+                            result.fullPath = file.path;
+                            successCallback([result]);
+                        }, function () {
+                            errorCallback(new CaptureError(CaptureError.CAPTURE_NO_MEDIA_FILES));
+                        });
                     }, function () {
                         errorCallback(new CaptureError(CaptureError.CAPTURE_NO_MEDIA_FILES));
                     });
-                }, function () {
+                } else {
                     errorCallback(new CaptureError(CaptureError.CAPTURE_NO_MEDIA_FILES));
-                });
+                }
             }, function () {
                 errorCallback(new CaptureError(CaptureError.CAPTURE_NO_MEDIA_FILES));
             });

--- a/src/windows/CaptureProxy.js
+++ b/src/windows/CaptureProxy.js
@@ -179,13 +179,18 @@ function MediaCaptureProxy() {
                             localFolder = Windows.Storage.ApplicationData.current.localFolder;
 
                         localFolder.createFileAsync("cameraCaptureVideo.mp4", generateUniqueCollisionOption).done(function(capturedFile) {
-                            capture.startRecordToStorageFileAsync(encodingProperties, capturedFile).done(function() {
-                                capturedVideoFile = capturedFile;
-                                captureStarted = true;
-                            }, function(err) {
+                            try {
+                                capture.startRecordToStorageFileAsync(encodingProperties, capturedFile).done(function () {
+                                    capturedVideoFile = capturedFile;
+                                    captureStarted = true;
+                                }, function (err) {
+                                    destroyCameraPreview();
+                                    errorCallback(CaptureError.CAPTURE_INTERNAL_ERR, err);
+                                });
+                            } catch(err) {
                                 destroyCameraPreview();
-                                errorCallback(CaptureError.CAPTURE_INTERNAL_ERR, err);
-                            });
+                                errorCallback(CaptureError.CAPTURE_NOT_SUPPORTED, err);
+                            }
                         }, function(err) {
                             destroyCameraPreview();
                             errorCallback(CaptureError.CAPTURE_INTERNAL_ERR, err);


### PR DESCRIPTION
App crashes due to an undefined file object being returned on cancel. 