### PR TITLE
CB-9249 Fix iOS warnings in Media Capture plugin Part 2

### DIFF
--- a/src/ios/CDVCapture.m
+++ b/src/ios/CDVCapture.m
@@ -516,7 +516,7 @@
         result = [self processImage:image type:cameraPicker.mimeType forCallbackId:callbackId];
     } else if ([mediaType isEqualToString:(NSString*)kUTTypeMovie]) {
         // process video
-        NSString* moviePath = [[info objectForKey:UIImagePickerControllerMediaURL] path];
+        NSString* moviePath = [(NSURL *)[info objectForKey:UIImagePickerControllerMediaURL] path];
         if (moviePath) {
             result = [self processVideo:moviePath forCallbackId:callbackId];
         }


### PR DESCRIPTION
Apparently this is a trivial change but I'd like someone to look it over.

This is where I got the fix:

https://github.com/inkling/Subliminal/issues/169