### PR TITLE
[CB-10554] Fix null reference in low memory conditions

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,14 @@ code.
 ### Android Quirks
 
 - The `duration` parameter is not supported.  Recording lengths can't be limited programmatically.
+- Android uses intents to launch the camera activity on the device to capture
+images, and on phones with low memory, the Cordova activity may be killed.  In this
+scenario, the result from the plugin call will be delivered via the resume event.
+See [the Android Lifecycle guide][android_lifecycle]
+for more information. The `pendingResult.result` value will contain the value that
+would be passed to the callbacks (either the URI/URL or an error message). Check
+the `pendingResult.pluginStatus` to determine whether or not the call was
+successful.
 
 ### BlackBerry 10 Quirks
 

--- a/src/android/Capture.java
+++ b/src/android/Capture.java
@@ -47,6 +47,7 @@ import android.database.Cursor;
 import android.graphics.BitmapFactory;
 import android.media.MediaPlayer;
 import android.net.Uri;
+import android.os.Bundle;
 import android.os.Environment;
 import android.provider.MediaStore;
 import android.util.Log;
@@ -159,7 +160,7 @@ public class Capture extends CordovaPlugin {
     /**
      * Get the Image specific attributes
      *
-     * @param filePath path to the file
+     * @param fileUrl path to the file
      * @param obj represents the Media File Data
      * @return a JSONObject that represents the Media File Data
      * @throws JSONException
@@ -256,7 +257,7 @@ public class Capture extends CordovaPlugin {
             intent.putExtra("android.intent.extra.durationLimit", duration);
             intent.putExtra("android.intent.extra.videoQuality", quality);
         }
-        this.cordova.startActivityForResult((CordovaPlugin) this, intent, CAPTURE_VIDEO);
+        this.cordova.startActivityForResult(this, intent, CAPTURE_VIDEO);
     }
 
     /**
@@ -418,6 +419,28 @@ public class Capture extends CordovaPlugin {
                 this.fail(createErrorObject(CAPTURE_NO_MEDIA_FILES, "Did not complete!"));
             }
         }
+    }
+
+    public Bundle onSaveInstanceState() {
+        Bundle state = new Bundle();
+
+        state.putLong("limit", this.limit);
+        state.putInt("duration", this.duration);
+        state.putInt("quality", this.quality);
+        state.putInt("numPics", this.numPics);
+
+        return state;
+    }
+
+    public void onRestoreStateForActivityResult(Bundle state, CallbackContext callbackContext) {
+        this.results = new JSONArray();
+
+        this.limit = state.getLong("limit");
+        this.duration = state.getInt("duration");
+        this.quality = state.getInt("quality");
+        this.numPics = state.getInt("numPics");
+
+        this.callbackContext = callbackContext;
     }
 
     /**


### PR DESCRIPTION
[Related Jira](https://issues.apache.org/jira/browse/CB-10554)
State is lost when the activity is not kept as a result of low memory conditions. This causes a NullPointerException in multiple places. Save the state and restore it on resume.