### PR TITLE
[CB-10488][CB-10489][CB-9611] Fix MediaFile.getFormatData (readded)

### DIFF
--- a/src/android/Capture.java
+++ b/src/android/Capture.java
@@ -25,6 +25,7 @@ import java.io.OutputStream;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.util.Arrays;
 
 import android.os.Build;
 
@@ -56,6 +57,7 @@ public class Capture extends CordovaPlugin {
     private static final String VIDEO_3GPP = "video/3gpp";
     private static final String VIDEO_MP4 = "video/mp4";
     private static final String AUDIO_3GPP = "audio/3gpp";
+    private static final String[] AUDIO_TYPES = new String[] {"audio/3gpp", "audio/aac", "audio/amr", "audio/wav"};
     private static final String IMAGE_JPEG = "image/jpeg";
 
     private static final int CAPTURE_AUDIO = 0;     // Constant for capture audio
@@ -147,7 +149,7 @@ public class Capture extends CordovaPlugin {
         if (mimeType.equals(IMAGE_JPEG) || filePath.endsWith(".jpg")) {
             obj = getImageData(fileUrl, obj);
         }
-        else if (mimeType.endsWith(AUDIO_3GPP)) {
+        else if (Arrays.asList(AUDIO_TYPES).contains(mimeType)) {
             obj = getAudioVideoData(filePath, obj, false);
         }
         else if (mimeType.equals(VIDEO_3GPP) || mimeType.equals(VIDEO_MP4)) {
@@ -454,7 +456,7 @@ public class Capture extends CordovaPlugin {
         try {
             // File properties
             obj.put("name", fp.getName());
-            obj.put("fullPath", fp.toURI().toString());
+            obj.put("fullPath", Uri.fromFile(fp));
             if (url != null) {
                 obj.put("localURL", url.toString());
             }

--- a/www/MediaFile.js
+++ b/www/MediaFile.js
@@ -48,7 +48,7 @@ MediaFile.prototype.getFormatData = function(successCallback, errorCallback) {
     if (typeof this.fullPath === "undefined" || this.fullPath === null) {
         errorCallback(new CaptureError(CaptureError.CAPTURE_INVALID_ARGUMENT));
     } else {
-        exec(successCallback, errorCallback, "Capture", "getFormatData", [this.localURL, this.type]);
+        exec(successCallback, errorCallback, "Capture", "getFormatData", [this.fullPath, this.type]);
     }
 };
 


### PR DESCRIPTION
JIRA Issue [CB-10488](https://issues.apache.org/jira/browse/CB-10488)
JIRA Issue [CB-10489](https://issues.apache.org/jira/browse/CB-10489)

Also resolves this one #43  / [CB-9611](https://issues.apache.org/jira/browse/CB-9611)

-------------
1. ``getFormatData`` was not working at all on Android (and iOS) because it was using the ``localURL`` instead of ``fullPath``
2. audio recording was not even checking for metadata because the current code is only searching for .3gpp audio files, but the default recording file type for android is ``audio/amr``.  
On my android 4.4, the Sound Recorder app has options from where the user can change the output file type (it has wav, amr & 3gpp); some devices are recording aac too.   
All these file types for audio recording are now supported.
3.  Related CB-9611 (PR#43) resolved without hardcoded ``file://`` string.