### PR TITLE
Removing global state and fixing CB-10670

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,6 +423,8 @@ Each `MediaFile` object describes a captured media file.
 
 - `CaptureError.CAPTURE_NO_MEDIA_FILES`: The user exits the camera or audio capture application before capturing anything.
 
+- `CaptureError.CAPTURE_PERMISSION_DENIED`: The user denied a permission required to perform the given capture request.
+
 - `CaptureError.CAPTURE_NOT_SUPPORTED`: The requested capture operation is not supported.
 
 ## CaptureErrorCB

--- a/plugin.xml
+++ b/plugin.xml
@@ -30,13 +30,13 @@ xmlns:rim="http://www.blackberry.com/ns/widgets"
     <keywords>cordova,media,capture</keywords>
     <repo>https://git-wip-us.apache.org/repos/asf/cordova-plugin-media-capture.git</repo>
     <issue>https://issues.apache.org/jira/browse/CB/component/12320646</issue>
-    
+
     <dependency id="cordova-plugin-file" version="^4.0.0" />
 
     <js-module src="www/CaptureAudioOptions.js" name="CaptureAudioOptions">
         <clobbers target="CaptureAudioOptions" />
     </js-module>
-    
+
     <js-module src="www/CaptureImageOptions.js" name="CaptureImageOptions">
         <clobbers target="CaptureImageOptions" />
     </js-module>
@@ -44,7 +44,7 @@ xmlns:rim="http://www.blackberry.com/ns/widgets"
     <js-module src="www/CaptureVideoOptions.js" name="CaptureVideoOptions">
         <clobbers target="CaptureVideoOptions" />
     </js-module>
-        
+
     <js-module src="www/CaptureError.js" name="CaptureError">
         <clobbers target="CaptureError" />
     </js-module>
@@ -52,11 +52,11 @@ xmlns:rim="http://www.blackberry.com/ns/widgets"
     <js-module src="www/MediaFileData.js" name="MediaFileData">
         <clobbers target="MediaFileData" />
     </js-module>
-        
+
     <js-module src="www/MediaFile.js" name="MediaFile">
         <clobbers target="MediaFile" />
     </js-module>
-    
+
     <js-module src="www/capture.js" name="capture">
         <clobbers target="navigator.device.capture" />
     </js-module>
@@ -68,7 +68,7 @@ xmlns:rim="http://www.blackberry.com/ns/widgets"
                 <param name="android-package" value="org.apache.cordova.mediacapture.Capture"/>
             </feature>
         </config-file>
-        
+
         <config-file target="AndroidManifest.xml" parent="/*">
             <uses-permission android:name="android.permission.RECORD_AUDIO" />
             <uses-permission android:name="android.permission.RECORD_VIDEO"/>
@@ -77,8 +77,9 @@ xmlns:rim="http://www.blackberry.com/ns/widgets"
 
         <source-file src="src/android/Capture.java" target-dir="src/org/apache/cordova/mediacapture" />
         <source-file src="src/android/FileHelper.java" target-dir="src/org/apache/cordova/mediacapture" />
+        <source-file src="src/android/PermissionHelper.java" target-dir="src/org/apache/cordova/mediacapture" />
     </platform>
-    
+
     <!-- amazon-fireos -->
     <platform name="amazon-fireos">
         <config-file target="res/xml/config.xml" parent="/*">
@@ -86,7 +87,7 @@ xmlns:rim="http://www.blackberry.com/ns/widgets"
                 <param name="android-package" value="org.apache.cordova.mediacapture.Capture"/>
             </feature>
         </config-file>
-        
+
         <config-file target="AndroidManifest.xml" parent="/*">
             <uses-permission android:name="android.permission.RECORD_AUDIO" />
             <uses-permission android:name="android.permission.RECORD_VIDEO"/>
@@ -96,7 +97,7 @@ xmlns:rim="http://www.blackberry.com/ns/widgets"
         <source-file src="src/android/Capture.java" target-dir="src/org/apache/cordova/mediacapture" />
         <source-file src="src/android/FileHelper.java" target-dir="src/org/apache/cordova/mediacapture" />
     </platform>
-    
+
 
     <!-- ubuntu -->
     <platform name="ubuntu">
@@ -122,16 +123,16 @@ xmlns:rim="http://www.blackberry.com/ns/widgets"
     </platform>
 
     <!-- ios -->
-    <platform name="ios">    
+    <platform name="ios">
         <config-file target="config.xml" parent="/*">
             <feature name="Capture">
-                <param name="ios-package" value="CDVCapture" /> 
+                <param name="ios-package" value="CDVCapture" />
             </feature>
         </config-file>
         <header-file src="src/ios/CDVCapture.h" />
         <source-file src="src/ios/CDVCapture.m" />
         <resource-file src="src/ios/CDVCapture.bundle" />
-        
+
         <framework src="CoreGraphics.framework" />
         <framework src="MobileCoreServices.framework" />
     </platform>

--- a/plugin.xml
+++ b/plugin.xml
@@ -78,6 +78,7 @@ xmlns:rim="http://www.blackberry.com/ns/widgets"
         <source-file src="src/android/Capture.java" target-dir="src/org/apache/cordova/mediacapture" />
         <source-file src="src/android/FileHelper.java" target-dir="src/org/apache/cordova/mediacapture" />
         <source-file src="src/android/PermissionHelper.java" target-dir="src/org/apache/cordova/mediacapture" />
+        <source-file src="src/android/PendingRequests.java" target-dir="src/org/apache/cordova/mediacapture" />
     </platform>
 
     <!-- amazon-fireos -->

--- a/src/android/PendingRequests.java
+++ b/src/android/PendingRequests.java
@@ -1,0 +1,132 @@
+/*
+       Licensed to the Apache Software Foundation (ASF) under one
+       or more contributor license agreements.  See the NOTICE file
+       distributed with this work for additional information
+       regarding copyright ownership.  The ASF licenses this file
+       to you under the Apache License, Version 2.0 (the
+       "License"); you may not use this file except in compliance
+       with the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing,
+       software distributed under the License is distributed on an
+       "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+       KIND, either express or implied.  See the License for the
+       specific language governing permissions and limitations
+       under the License.
+*/
+
+package org.apache.cordova.mediacapture;
+
+import android.util.SparseArray;
+
+import org.apache.cordova.CallbackContext;
+import org.apache.cordova.PluginResult;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+/**
+ * Holds the pending javascript requests for the plugin
+ */
+public class PendingRequests {
+    private int currentReqId = 0;
+    private SparseArray<Request> requests = new SparseArray<Request>();
+
+    /**
+     * Creates a request and adds it to the array of pending requests. Each created request gets a
+     * unique result code for use with startActivityForResult() and requestPermission()
+     * @param action            The action this request corresponds to (capture image, capture audio, etc.)
+     * @param options           The options for this request passed from the javascript
+     * @param callbackContext   The CallbackContext to return the result to
+     * @return                  The newly created Request object with a unique result code
+     * @throws JSONException
+     */
+    public synchronized Request createRequest(int action, JSONObject options, CallbackContext callbackContext) throws JSONException {
+        Request req = new Request(action, options, callbackContext);
+        requests.put(req.requestCode, req);
+        return req;
+    }
+
+    /**
+     * Gets the request corresponding to this request code
+     * @param requestCode   The request code for the desired request
+     * @return              The request corresponding to the given request code or null if such a
+     *                      request is not found
+     */
+    public synchronized Request get(int requestCode) {
+        return requests.get(requestCode);
+    }
+
+    /**
+     * Removes the request from the array of pending requests and sends an error plugin result
+     * to the CallbackContext that contains the given error object
+     * @param req   The request to be resolved
+     * @param error The error to be returned to the CallbackContext
+     */
+    public synchronized void resolveWithFailure(Request req, JSONObject error) {
+        req.callbackContext.error(error);
+        requests.remove(req.requestCode);
+    }
+
+    /**
+     * Removes the request from the array of pending requests and sends a successful plugin result
+     * to the CallbackContext that contains the result of the request
+     * @param req   The request to be resolved
+     */
+    public synchronized void resolveWithSuccess(Request req) {
+        req.callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.OK, req.results));
+        requests.remove(req.requestCode);
+    }
+
+
+    /**
+     * Each request gets a unique ID that represents its request code when calls are made to
+     * Activities and for permission requests
+     * @return  A unique request code
+     */
+    private synchronized int incrementCurrentReqId() {
+        return currentReqId ++;
+    }
+
+    /**
+     * Holds the options and CallbackContext for a capture request made to the plugin.
+     */
+    public class Request {
+
+        // Unique int used to identify this request in any Android Permission or Activity callbacks
+        public int requestCode;
+
+        // The action that this request is performing
+        public int action;
+
+        // The number of pics/vids/audio clips to take (CAPTURE_IMAGE, CAPTURE_VIDEO, CAPTURE_AUDIO)
+        public long limit = 1;
+
+        // Optional max duration of recording in seconds (CAPTURE_VIDEO only)
+        public int duration = 0;
+
+        // Quality level for video capture 0 low, 1 high (CAPTURE_VIDEO only)
+        public int quality = 1;
+
+        // The array of results to be returned to the javascript callback on success
+        public JSONArray results = new JSONArray();
+
+        // The callback context for this plugin request
+        private CallbackContext callbackContext;
+
+        private Request(int action, JSONObject options, CallbackContext callbackContext) throws JSONException {
+            this.callbackContext = callbackContext;
+            this.action = action;
+
+            if (options != null) {
+                this.limit = options.optLong("limit", 1);
+                this.duration = options.optInt("duration", 0);
+                this.quality = options.optInt("quality", 1);
+            }
+
+            this.requestCode = incrementCurrentReqId();
+        }
+    }
+}

--- a/src/android/PermissionHelper.java
+++ b/src/android/PermissionHelper.java
@@ -1,0 +1,138 @@
+/*
+       Licensed to the Apache Software Foundation (ASF) under one
+       or more contributor license agreements.  See the NOTICE file
+       distributed with this work for additional information
+       regarding copyright ownership.  The ASF licenses this file
+       to you under the Apache License, Version 2.0 (the
+       "License"); you may not use this file except in compliance
+       with the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing,
+       software distributed under the License is distributed on an
+       "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+       KIND, either express or implied.  See the License for the
+       specific language governing permissions and limitations
+       under the License.
+*/
+package org.apache.cordova.mediacapture;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+
+import org.apache.cordova.CordovaInterface;
+import org.apache.cordova.CordovaPlugin;
+import org.apache.cordova.LOG;
+
+import android.content.pm.PackageManager;
+
+/**
+ * This class provides reflective methods for permission requesting and checking so that plugins
+ * written for cordova-android 5.0.0+ can still compile with earlier cordova-android versions.
+ */
+public class PermissionHelper {
+    private static final String LOG_TAG = "CordovaPermissionHelper";
+
+    /**
+     * Requests a "dangerous" permission for the application at runtime. This is a helper method
+     * alternative to cordovaInterface.requestPermission() that does not require the project to be
+     * built with cordova-android 5.0.0+
+     *
+     * @param plugin        The plugin the permission is being requested for
+     * @param requestCode   A requestCode to be passed to the plugin's onRequestPermissionResult()
+     *                      along with the result of the permission request
+     * @param permission    The permission to be requested
+     */
+    public static void requestPermission(CordovaPlugin plugin, int requestCode, String permission) {
+        PermissionHelper.requestPermissions(plugin, requestCode, new String[] {permission});
+    }
+
+    /**
+     * Requests "dangerous" permissions for the application at runtime. This is a helper method
+     * alternative to cordovaInterface.requestPermissions() that does not require the project to be
+     * built with cordova-android 5.0.0+
+     *
+     * @param plugin        The plugin the permissions are being requested for
+     * @param requestCode   A requestCode to be passed to the plugin's onRequestPermissionResult()
+     *                      along with the result of the permissions request
+     * @param permissions   The permissions to be requested
+     */
+    public static void requestPermissions(CordovaPlugin plugin, int requestCode, String[] permissions) {
+        try {
+            Method requestPermission = CordovaInterface.class.getDeclaredMethod(
+                    "requestPermissions", CordovaPlugin.class, int.class, String[].class);
+
+            // If there is no exception, then this is cordova-android 5.0.0+
+            requestPermission.invoke(plugin.cordova, plugin, requestCode, permissions);
+        } catch (NoSuchMethodException noSuchMethodException) {
+            // cordova-android version is less than 5.0.0, so permission is implicitly granted
+            LOG.d(LOG_TAG, "No need to request permissions " + Arrays.toString(permissions));
+
+            // Notify the plugin that all were granted by using more reflection
+            deliverPermissionResult(plugin, requestCode, permissions);
+        } catch (IllegalAccessException illegalAccessException) {
+            // Should never be caught; this is a public method
+            LOG.e(LOG_TAG, "IllegalAccessException when requesting permissions " + Arrays.toString(permissions), illegalAccessException);
+        } catch(InvocationTargetException invocationTargetException) {
+            // This method does not throw any exceptions, so this should never be caught
+            LOG.e(LOG_TAG, "invocationTargetException when requesting permissions " + Arrays.toString(permissions), invocationTargetException);
+        }
+    }
+
+    /**
+     * Checks at runtime to see if the application has been granted a permission. This is a helper
+     * method alternative to cordovaInterface.hasPermission() that does not require the project to
+     * be built with cordova-android 5.0.0+
+     *
+     * @param plugin        The plugin the permission is being checked against
+     * @param permission    The permission to be checked
+     *
+     * @return              True if the permission has already been granted and false otherwise
+     */
+    public static boolean hasPermission(CordovaPlugin plugin, String permission) {
+        try {
+            Method hasPermission = CordovaInterface.class.getDeclaredMethod("hasPermission", String.class);
+
+            // If there is no exception, then this is cordova-android 5.0.0+
+            return (Boolean) hasPermission.invoke(plugin.cordova, permission);
+        } catch (NoSuchMethodException noSuchMethodException) {
+            // cordova-android version is less than 5.0.0, so permission is implicitly granted
+            LOG.d(LOG_TAG, "No need to check for permission " + permission);
+            return true;
+        } catch (IllegalAccessException illegalAccessException) {
+            // Should never be caught; this is a public method
+            LOG.e(LOG_TAG, "IllegalAccessException when checking permission " + permission, illegalAccessException);
+        } catch(InvocationTargetException invocationTargetException) {
+            // This method does not throw any exceptions, so this should never be caught
+            LOG.e(LOG_TAG, "invocationTargetException when checking permission " + permission, invocationTargetException);
+        }
+        return false;
+    }
+
+    private static void deliverPermissionResult(CordovaPlugin plugin, int requestCode, String[] permissions) {
+        // Generate the request results
+        int[] requestResults = new int[permissions.length];
+        Arrays.fill(requestResults, PackageManager.PERMISSION_GRANTED);
+
+        try {
+            Method onRequestPermissionResult = CordovaPlugin.class.getDeclaredMethod(
+                    "onRequestPermissionResult", int.class, String[].class, int[].class);
+
+            onRequestPermissionResult.invoke(plugin, requestCode, permissions, requestResults);
+        } catch (NoSuchMethodException noSuchMethodException) {
+            // Should never be caught since the plugin must be written for cordova-android 5.0.0+ if it
+            // made it to this point
+            LOG.e(LOG_TAG, "NoSuchMethodException when delivering permissions results", noSuchMethodException);
+        } catch (IllegalAccessException illegalAccessException) {
+            // Should never be caught; this is a public method
+            LOG.e(LOG_TAG, "IllegalAccessException when delivering permissions results", illegalAccessException);
+        } catch(InvocationTargetException invocationTargetException) {
+            // This method may throw a JSONException. We are just duplicating cordova-android's
+            // exception handling behavior here; all it does is log the exception in CordovaActivity,
+            // print the stacktrace, and ignore it
+            LOG.e(LOG_TAG, "InvocationTargetException when delivering permissions results", invocationTargetException);
+        }
+    }
+}

--- a/www/CaptureError.js
+++ b/www/CaptureError.js
@@ -34,6 +34,8 @@ CaptureError.CAPTURE_APPLICATION_BUSY = 1;
 CaptureError.CAPTURE_INVALID_ARGUMENT = 2;
 // User exited camera application or audio capture application before capturing anything.
 CaptureError.CAPTURE_NO_MEDIA_FILES = 3;
+// User denied permissions required to perform the capture request.
+CaptureError.CAPTURE_PERMISSION_DENIED = 4;
 // The requested capture operation is not supported.
 CaptureError.CAPTURE_NOT_SUPPORTED = 20;
 


### PR DESCRIPTION
There are two parts to this PR.

The first is to fix Marshmallow permissions (CB-10670). `captureImage()` was not requesting `READ_EXTERNAL_STORAGE` and both `captureImage()` and `captureVideo()` needed the fix that was recently done in the camera plugin for the `CAMERA` permission (https://github.com/apache/cordova-plugin-camera/pull/179).

The second was to remove the global state being maintained in the plugin. This caused a lot of issues when async calls to the plugin overlap. It is included in this PR because most of them are related to async Android calls like requesting permissions and launching external Activities (see also https://github.com/apache/cordova-android/pull/285). I'm planning on doing a similar fix for the file plugin soon.