### PR TITLE
CB-11629: (iOS) Implement 'animated' property and updated English docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,8 @@ capturing a video clip, the `CaptureErrorCB` callback executes with a
 
 ### Properties
 
+- __animated__: Whether or not the audio recording interface shows and hides using an animatied transition. (defaults to true).
+
 - __limit__: The maximum number of audio clips the device user can record in a single capture operation.  The value must be greater than or equal to 1 (defaults to 1).
 
 - __duration__: The maximum duration of an audio sound clip, in seconds.
@@ -312,14 +314,17 @@ capturing a video clip, the `CaptureErrorCB` callback executes with a
 
 ### Amazon Fire OS Quirks
 
+- The __animated__ property is not supported.
 - The `duration` parameter is not supported.  Recording lengths cannot be limited programmatically.
 
 ### Android Quirks
 
+- The __animated__ property is not supported.
 - The `duration` parameter is not supported.  Recording lengths can't be limited programmatically.
 
 ### BlackBerry 10 Quirks
 
+- The __animated__ property is not supported.
 - The `duration` parameter is not supported.  Recording lengths can't be limited programmatically.
 - The `limit` parameter is not supported, so only one recording can be created for each invocation.
 
@@ -327,12 +332,16 @@ capturing a video clip, the `CaptureErrorCB` callback executes with a
 
 - The `limit` parameter is not supported, so only one recording can be created for each invocation.
 
+### Windows Quirks
+- The __animated__ property is not supported.
 
 ## CaptureImageOptions
 
 > Encapsulates image capture configuration options.
 
 ### Properties
+
+- __animated__: Whether or not the camera interface shows and hides using an animatied transition. (defaults to true).
 
 - __limit__: The maximum number of images the user can capture in a single capture operation. The value must be greater than or equal to 1 (defaults to 1).
 
@@ -343,16 +352,33 @@ capturing a video clip, the `CaptureErrorCB` callback executes with a
 
     navigator.device.capture.captureImage(captureSuccess, captureError, options);
 
+### Amazon Fire OS Quirks
+
+- The __animated__ property is not supported.
+
+### Android Quirks
+
+- The __animated__ property is not supported.
+
+### BlackBerry 10 Quirks
+
+- The __animated__ property is not supported.
+
 ### iOS Quirks
 
 - The __limit__ parameter is not supported, and only one image is taken per invocation.
 
+### Windows Quirks
+
+- The __animated__ property is not supported.
 
 ## CaptureVideoOptions
 
 > Encapsulates video capture configuration options.
 
 ### Properties
+
+- __animated__: Whether or not the camera interface shows and hides using an animatied transition. (defaults to true).
 
 - __limit__: The maximum number of video clips the device's user can capture in a single capture operation.  The value must be greater than or equal to 1 (defaults to 1).
 
@@ -365,16 +391,26 @@ capturing a video clip, the `CaptureErrorCB` callback executes with a
 
     navigator.device.capture.captureVideo(captureSuccess, captureError, options);
 
+### Amazon Fire OS Quirks
+
+- The __animated__ property is not supported.
+
 ### BlackBerry 10 Quirks
 
+- The __animated__ property is not supported.
 - The __duration__ property is ignored, so the length of recordings can't be limited programmatically.
 
 ### iOS Quirks
 
 - The __limit__ property is ignored.  Only one video is recorded per invocation.
 
+### Windows Quirks
+
+- The __animated__ property is not supported.
+
 ### Android Quirks
 
+- The __animated__ property is not supported.
 - Android supports an additional __quality__ property, to allow capturing video at different qualities.  A value of `1` ( the default ) means high quality and value of `0` means low quality, suitable for MMS messages.
   See [here](http://developer.android.com/reference/android/provider/MediaStore.html#EXTRA_VIDEO_QUALITY) for more details.
 

--- a/src/ios/CDVCapture.h
+++ b/src/ios/CDVCapture.h
@@ -48,8 +48,10 @@ typedef NSUInteger CDVCaptureError;
 {
     CDVImagePicker* pickerController;
     BOOL inUse;
+    BOOL isAnimated;
 }
 @property BOOL inUse;
+@property BOOL isAnimated;
 - (void)captureAudio:(CDVInvokedUrlCommand*)command;
 - (void)captureImage:(CDVInvokedUrlCommand*)command;
 - (CDVPluginResult*)processImage:(UIImage*)image type:(NSString*)mimeType forCallbackId:(NSString*)callbackId;
@@ -92,6 +94,7 @@ typedef NSUInteger CDVCaptureError;
     CDVPluginResult* pluginResult;
     NSTimer* timer;
     BOOL isTimed;
+    BOOL isAnimated;
 }
 @property (nonatomic) CDVCaptureError errorCode;
 @property (nonatomic, copy) NSString* callbackId;
@@ -108,6 +111,7 @@ typedef NSUInteger CDVCaptureError;
 @property (nonatomic, strong) CDVPluginResult* pluginResult;
 @property (nonatomic, strong) NSTimer* timer;
 @property (nonatomic) BOOL isTimed;
+@property (nonatomic) BOOL isAnimated;
 
 - (id)initWithCommand:(CDVPlugin*)theCommand duration:(NSNumber*)theDuration callbackId:(NSString*)theCallbackId;
 - (void)processButton:(id)sender;

--- a/src/ios/CDVCapture.m
+++ b/src/ios/CDVCapture.m
@@ -76,10 +76,12 @@
 
 @implementation CDVCapture
 @synthesize inUse;
+@synthesize isAnimated;
 
 - (void)pluginInitialize
 {
     self.inUse = NO;
+    self.isAnimated = YES;
 }
 
 - (void)captureAudio:(CDVInvokedUrlCommand*)command
@@ -89,6 +91,11 @@
 
     if ([options isKindOfClass:[NSNull class]]) {
         options = [NSDictionary dictionary];
+    }
+
+    NSNumber* animated = [options objectForKey:@"animated"];
+    if (animated) {
+        self.isAnimated = [animated boolValue];
     }
 
     NSNumber* duration = [options objectForKey:@"duration"];
@@ -105,13 +112,14 @@
     } else {
         // all the work occurs here
         CDVAudioRecorderViewController* audioViewController = [[CDVAudioRecorderViewController alloc] initWithCommand:self duration:duration callbackId:callbackId];
+        audioViewController.isAnimated = self.isAnimated;
 
         // Now create a nav controller and display the view...
         CDVAudioNavigationController* navController = [[CDVAudioNavigationController alloc] initWithRootViewController:audioViewController];
 
         self.inUse = YES;
 
-        [self.viewController presentViewController:navController animated:YES completion:nil];
+        [self.viewController presentViewController:navController animated:self.isAnimated completion:nil];
     }
 
     if (result) {
@@ -131,6 +139,10 @@
     // options could contain limit and mode neither of which are supported at this time
     // taking more than one picture (limit) is only supported if provide own controls via cameraOverlayView property
     // can support mode in OS
+    NSNumber* animated = [options objectForKey:@"animated"];
+    if (animated) {
+        self.isAnimated = [animated boolValue];
+    }
 
     if (![UIImagePickerController isSourceTypeAvailable:UIImagePickerControllerSourceTypeCamera]) {
         NSLog(@"Capture.imageCapture: camera not available.");
@@ -158,7 +170,7 @@
         // CDVImagePicker specific property
         pickerController.callbackId = callbackId;
 
-        [self.viewController presentViewController:pickerController animated:YES completion:nil];
+        [self.viewController presentViewController:pickerController animated:self.isAnimated completion:nil];
     }
 }
 
@@ -221,6 +233,11 @@
 
     // options could contain limit, duration and mode
     // taking more than one video (limit) is only supported if provide own controls via cameraOverlayView property
+    NSNumber* animated = [options objectForKey:@"animated"];
+    if (animated) {
+        self.isAnimated = [animated boolValue];
+    }
+
     NSNumber* duration = [options objectForKey:@"duration"];
     NSString* mediaType = nil;
 
@@ -270,7 +287,7 @@
         // CDVImagePicker specific property
         pickerController.callbackId = callbackId;
 
-        [self.viewController presentViewController:pickerController animated:YES completion:nil];
+        [self.viewController presentViewController:pickerController animated:self.isAnimated completion:nil];
     }
 }
 
@@ -496,7 +513,7 @@
     CDVImagePicker* cameraPicker = (CDVImagePicker*)picker;
     NSString* callbackId = cameraPicker.callbackId;
 
-    [[picker presentingViewController] dismissViewControllerAnimated:YES completion:nil];
+    [[picker presentingViewController] dismissViewControllerAnimated:self.isAnimated completion:nil];
 
     CDVPluginResult* result = nil;
 
@@ -533,7 +550,7 @@
     CDVImagePicker* cameraPicker = (CDVImagePicker*)picker;
     NSString* callbackId = cameraPicker.callbackId;
 
-    [[picker presentingViewController] dismissViewControllerAnimated:YES completion:nil];
+    [[picker presentingViewController] dismissViewControllerAnimated:self.isAnimated completion:nil];
 
     CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageToErrorObject:CAPTURE_NO_MEDIA_FILES];
     [self.commandDelegate sendPluginResult:result callbackId:callbackId];
@@ -566,7 +583,7 @@
 @end
 
 @implementation CDVAudioRecorderViewController
-@synthesize errorCode, callbackId, duration, captureCommand, doneButton, recordingView, recordButton, recordImage, stopRecordImage, timerLabel, avRecorder, avSession, pluginResult, timer, isTimed;
+@synthesize errorCode, callbackId, duration, captureCommand, doneButton, recordingView, recordButton, recordImage, stopRecordImage, timerLabel, avRecorder, avSession, pluginResult, timer, isTimed, isAnimated;
 
 - (NSString*)resolveImageResource:(NSString*)resource
 {
@@ -850,7 +867,7 @@
 - (void)dismissAudioView:(id)sender
 {
     // called when done button pressed or when error condition to do cleanup and remove view
-    [[self.captureCommand.viewController.presentedViewController presentingViewController] dismissViewControllerAnimated:YES completion:nil];
+    [[self.captureCommand.viewController.presentedViewController presentingViewController] dismissViewControllerAnimated:self.isAnimated completion:nil];
 
     if (!self.pluginResult) {
         // return error


### PR DESCRIPTION
### Platforms affected
iOS

### What does this PR do?
Add property 'animated' to optionally disable native screen animations.
As iOS does not support the limit flag; capturing multiple images by calling
this plugin in a loop can be quite slow for end users.

### What testing has been done on this change?
captureImage()
  'animated' omitted / true / false

captureVideo()
  'animated' omitted / true / false