### PR TITLE
CB-10180: (iOS) implement the 'quality' property in captureVideo()

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,6 +372,10 @@ capturing a video clip, the `CaptureErrorCB` callback executes with a
 ### iOS Quirks
 
 - The __limit__ property is ignored.  Only one video is recorded per invocation.
+- iOS supports an additional __quality__ property, to allow capturing video at different qualities.  A value of `1` means high quality and value of `0` ( the default ) means low quality, suitable for MMS messages.
+  See [here](https://developer.apple.com/reference/uikit/uiimagepickercontrollerqualitytype?language=objc) for more details.
+  A value of 0 corresponds to UIImagePickerControllerQualityTypeMedium (the default value of the [UIImagePickerController.videoQuality](https://developer.apple.com/reference/uikit/uiimagepickercontroller/1619154-videoquality?language=objc) property)
+  A value of 1 corresponds to UIImagePickerControllerQualityTypeHigh
 
 ### Android Quirks
 

--- a/src/ios/CDVCapture.m
+++ b/src/ios/CDVCapture.m
@@ -219,10 +219,11 @@
         options = [NSDictionary dictionary];
     }
 
-    // options could contain limit, duration and mode
+    // options could contain duration, limit, mode and quality
     // taking more than one video (limit) is only supported if provide own controls via cameraOverlayView property
     NSNumber* duration = [options objectForKey:@"duration"];
     NSString* mediaType = nil;
+    NSNumber* quality = [options objectForKey:@"quality"];
 
     if ([UIImagePickerController isSourceTypeAvailable:UIImagePickerControllerSourceTypeCamera]) {
         // there is a camera, it is available, make sure it can do movies
@@ -263,7 +264,9 @@
         // iOS 4.0
         if ([pickerController respondsToSelector:@selector(cameraCaptureMode)]) {
             pickerController.cameraCaptureMode = UIImagePickerControllerCameraCaptureModeVideo;
-            // pickerController.videoQuality = UIImagePickerControllerQualityTypeHigh;
+            if (quality && [quality intValue] == 1) {
+                pickerController.videoQuality = UIImagePickerControllerQualityTypeHigh;
+            }
             // pickerController.cameraDevice = UIImagePickerControllerCameraDeviceRear;
             // pickerController.cameraFlashMode = UIImagePickerControllerCameraFlashModeAuto;
         }


### PR DESCRIPTION
### Platforms affected
iOS

### What does this PR do?
implement quality property for video capture.

### What testing has been done on this change?
captureVideo()
  'quality' omitted / 1 / 0