### PR TITLE
CB-11630: (iOS) Implement property 'quality' in captureImage()

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,8 @@ capturing a video clip, the `CaptureErrorCB` callback executes with a
 ### iOS Quirks
 
 - The __limit__ parameter is not supported, and only one image is taken per invocation.
+- iOS supports an additional __quality__ property, to allow modification of the JPEG compression quality.  The value must be greather than or equal to 0 and less than or equal to 1 (defaults to 0.5).
+See [here](https://developer.apple.com/reference/uikit/1624115-uiimagejpegrepresentation?language=objc) for more details.
 
 
 ## CaptureVideoOptions

--- a/src/ios/CDVCapture.h
+++ b/src/ios/CDVCapture.h
@@ -48,8 +48,10 @@ typedef NSUInteger CDVCaptureError;
 {
     CDVImagePicker* pickerController;
     BOOL inUse;
+    CGFloat jpegCompression;
 }
 @property BOOL inUse;
+@property CGFloat jpegCompression;
 - (void)captureAudio:(CDVInvokedUrlCommand*)command;
 - (void)captureImage:(CDVInvokedUrlCommand*)command;
 - (CDVPluginResult*)processImage:(UIImage*)image type:(NSString*)mimeType forCallbackId:(NSString*)callbackId;

--- a/src/ios/CDVCapture.m
+++ b/src/ios/CDVCapture.m
@@ -76,10 +76,12 @@
 
 @implementation CDVCapture
 @synthesize inUse;
+@synthesize jpegCompression;
 
 - (void)pluginInitialize
 {
     self.inUse = NO;
+    self.jpegCompression = 0.5;
 }
 
 - (void)captureAudio:(CDVInvokedUrlCommand*)command
@@ -128,9 +130,16 @@
         options = [NSDictionary dictionary];
     }
 
-    // options could contain limit and mode neither of which are supported at this time
+    // options could contain limit, mode and quality
     // taking more than one picture (limit) is only supported if provide own controls via cameraOverlayView property
     // can support mode in OS
+    NSNumber* quality = [options objectForKey:@"quality"];
+    if (quality) {
+        CGFloat qualityValue = [quality floatValue];
+        if (qualityValue >= 0 && qualityValue <= 1) {
+            self.jpegCompression = qualityValue;
+        }
+    }
 
     if (![UIImagePickerController isSourceTypeAvailable:UIImagePickerControllerSourceTypeCamera]) {
         NSLog(@"Capture.imageCapture: camera not available.");
@@ -178,7 +187,7 @@
     if (mimeType && [mimeType isEqualToString:@"image/png"]) {
         data = UIImagePNGRepresentation(image);
     } else {
-        data = UIImageJPEGRepresentation(image, 0.5);
+        data = UIImageJPEGRepresentation(image, self.jpegCompression);
     }
 
     // write to temp directory and return URI


### PR DESCRIPTION
### Platforms affected
iOS

### What does this PR do?
Allows developers to set JPEG compression quality

### What testing has been done on this change?
captureImage()
  'quality' omitted / 0 / 0.0 / 0.1 / 0.3 / 0.5 / 0.96 / 0.99 / 1 / 100

### Checklist
- [X] [ICLA](http://www.apache.org/licenses/icla.txt) has been signed and submitted to secretary@apache.org.
- [X] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [X] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [X] Added automated test coverage as appropriate for this change.
