### PR TITLE
CB-11995 (android) Do not pass a file uri to the camera

### DIFF
--- a/src/android/Capture.java
+++ b/src/android/Capture.java
@@ -44,6 +44,7 @@ import org.json.JSONObject;
 
 import android.Manifest;
 import android.app.Activity;
+import android.content.ContentResolver;
 import android.content.ContentValues;
 import android.content.Intent;
 import android.content.pm.PackageManager;
@@ -78,6 +79,7 @@ public class Capture extends CordovaPlugin {
     private final PendingRequests pendingRequests = new PendingRequests();
 
     private int numPics;                            // Number of pictures before capture activity
+    private Uri imageUri;
 
 //    public void setContext(Context mCtx)
 //    {
@@ -266,16 +268,13 @@ public class Capture extends CordovaPlugin {
 
             Intent intent = new Intent(android.provider.MediaStore.ACTION_IMAGE_CAPTURE);
 
-            // Specify file so that large image is captured and returned
-            File photo = new File(getTempDirectoryPath(), "Capture.jpg");
-            try {
-                // the ACTION_IMAGE_CAPTURE is run under different credentials and has to be granted write permissions
-                createWritableFile(photo);
-            } catch (IOException ex) {
-                pendingRequests.resolveWithFailure(req, createErrorObject(CAPTURE_INTERNAL_ERR, ex.toString()));
-                return;
-            }
-            intent.putExtra(android.provider.MediaStore.EXTRA_OUTPUT, Uri.fromFile(photo));
+            ContentResolver contentResolver = this.cordova.getActivity().getContentResolver();
+            ContentValues cv = new ContentValues();
+            cv.put(MediaStore.Images.Media.MIME_TYPE, IMAGE_JPEG);
+            imageUri = contentResolver.insert(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, cv);
+            LOG.d(LOG_TAG, "Taking a picture and saving to: " + imageUri.toString());
+
+            intent.putExtra(android.provider.MediaStore.EXTRA_OUTPUT, imageUri);
 
             this.cordova.startActivityForResult((CordovaPlugin) this, intent, req.requestCode);
         }
@@ -377,54 +376,17 @@ public class Capture extends CordovaPlugin {
     }
 
     public void onImageActivityResult(Request req) {
-        // For some reason if I try to do:
-        // Uri data = intent.getData();
-        // It crashes in the emulator and on my phone with a null pointer exception
-        // To work around it I had to grab the code from CameraLauncher.java
-        try {
-            // Create entry in media store for image
-            // (Don't use insertImage() because it uses default compression setting of 50 - no way to change it)
-            ContentValues values = new ContentValues();
-            values.put(android.provider.MediaStore.Images.Media.MIME_TYPE, IMAGE_JPEG);
-            Uri uri = null;
-            try {
-                uri = this.cordova.getActivity().getContentResolver().insert(android.provider.MediaStore.Images.Media.EXTERNAL_CONTENT_URI, values);
-            } catch (UnsupportedOperationException e) {
-                LOG.d(LOG_TAG, "Can't write to external media storage.");
-                try {
-                    uri = this.cordova.getActivity().getContentResolver().insert(android.provider.MediaStore.Images.Media.INTERNAL_CONTENT_URI, values);
-                } catch (UnsupportedOperationException ex) {
-                    LOG.d(LOG_TAG, "Can't write to internal media storage.");
-                    pendingRequests.resolveWithFailure(req, createErrorObject(CAPTURE_INTERNAL_ERR, "Error capturing image - no media storage found."));
-                    return;
-                }
-            }
-            FileInputStream fis = new FileInputStream(getTempDirectoryPath() + "/Capture.jpg");
-            OutputStream os = this.cordova.getActivity().getContentResolver().openOutputStream(uri);
-            byte[] buffer = new byte[4096];
-            int len;
-            while ((len = fis.read(buffer)) != -1) {
-                os.write(buffer, 0, len);
-            }
-            os.flush();
-            os.close();
-            fis.close();
+        // Add image to results
+        req.results.put(createMediaFile(imageUri));
 
-            // Add image to results
-            req.results.put(createMediaFile(uri));
+        checkForDuplicateImage();
 
-            checkForDuplicateImage();
-
-            if (req.results.length() >= req.limit) {
-                // Send Uri back to JavaScript for viewing image
-                pendingRequests.resolveWithSuccess(req);
-            } else {
-                // still need to capture more images
-                captureImage(req);
-            }
-        } catch (IOException e) {
-            e.printStackTrace();
-            pendingRequests.resolveWithFailure(req, createErrorObject(CAPTURE_INTERNAL_ERR, "Error capturing image."));
+        if (req.results.length() >= req.limit) {
+            // Send Uri back to JavaScript for viewing image
+            pendingRequests.resolveWithSuccess(req);
+        } else {
+            // still need to capture more images
+            captureImage(req);
         }
     }
 


### PR DESCRIPTION
### Platforms affected
Android

### What does this PR do?
Fixes an image capture not to throw a FileUriExposedException on Android 7.0
https://issues.apache.org/jira/browse/CB-11995

### What testing has been done on this change?
Tested on Android 7.0 emulator as well as on various API level 19-22 emulators.

### Checklist
- [x] [Reported an issue](https://issues.apache.org/jira/browse/CB-11995) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change - *this can be tested only by manual test*.

