### PR TITLE
Suport iPhone 6

### DIFF
--- a/src/ios/CDVCapture.m
+++ b/src/ios/CDVCapture.m
@@ -615,10 +615,21 @@
 
     // make backgrounds
     NSString* microphoneResource = @"CDVCapture.bundle/microphone";
-
-    BOOL isIphone5 = ([[UIScreen mainScreen] bounds].size.width == 568 && [[UIScreen mainScreen] bounds].size.height == 320) || ([[UIScreen mainScreen] bounds].size.height == 568 && [[UIScreen mainScreen] bounds].size.width == 320);
-    if (isIphone5) {
+    int maxLength = MAX([[UIScreen mainScreen] bounds].size.width, [[UIScreen mainScreen] bounds].size.height);
+    
+    BOOL isIphone5 = maxLength == 568;
+    if ( isIphone5 ) {
         microphoneResource = @"CDVCapture.bundle/microphone-568h";
+    }
+    
+    BOOL isIphone6 = maxLength == 667;
+    if ( isIphone6 ) {
+        microphoneResource = @"CDVCapture.bundle/microphone-667h";
+    }
+    
+    BOOL isIphone6p = maxLength == 736;
+    if ( isIphone6p ) {
+        microphoneResource = @"CDVCapture.bundle/microphone-736h";
     }
 
     NSBundle* cdvBundle = [NSBundle bundleForClass:[CDVCapture class]];


### PR DESCRIPTION
Adding image to support iPhone 6

### Platforms affected
iPhone 6, iPhone 6s, iPhone 6s Plus and iPhone 6 Plus

### What does this PR do?
Adds two new images for iPhone 6

### What testing has been done on this change?
This in two app in production

### Two missing images from CDVCapture.bundle?
https://drive.google.com/open?id=0B0IJT5Rizu5ORkZyOWNHdkwzdXc

### Checklist
- [ ] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
