### PR TITLE
CB-13266 (ios): Remove ios usage descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,26 +200,34 @@ object featuring a `CaptureError.CAPTURE_NO_MEDIA_FILES` error code.
 
 ### iOS Quirks
 
-Since iOS 10 it's mandatory to add a `NSCameraUsageDescription`, `NSMicrophoneUsageDescription` and `NSPhotoLibraryUsageDescriptionentry` in the info.plist.
+Since iOS 10 it's mandatory to provide an usage description in the `info.plist` if trying to access privacy-sensitive data. When the system prompts the user to allow access, this usage description string will displayed as part of the permission dialog box, but if you didn't provide the usage description, the app will crash before showing the dialog. Also, Apple will reject apps that access private data but don't provide an usage description.
 
-* `NSCameraUsageDescription` describes the reason that the app accesses the user’s camera.
-* `NSMicrophoneUsageDescription` describes the reason that the app accesses the user’s microphone.
+This plugins requires the following usage descriptions:
+
+* `NSCameraUsageDescription` describes the reason the app accesses the user's camera.
+* `NSMicrophoneUsageDescription` describes the reason the app accesses the user's microphone.
 * `NSPhotoLibraryUsageDescriptionentry` describes the reason the app accesses the user's photo library.
 
-When the system prompts the user to allow access, this string is displayed as part of the dialog box.
 
-To add this entry you can pass the following variables on plugin install.
+To add these entries into the `info.plist`, you can use the `edit-config` tag in the `config.xml` like this:
 
-* `CAMERA_USAGE_DESCRIPTION` for `NSCameraUsageDescription`
-* `MICROPHONE_USAGE_DESCRIPTION` for `NSMicrophoneUsageDescription`
-* `PHOTOLIBRARY_USAGE_DESCRIPTION` for `NSPhotoLibraryUsageDescriptionentry`
+```
+<edit-config target="NSCameraUsageDescription" file="*-Info.plist" mode="merge">
+    <string>need camera access to take pictures</string>
+</edit-config>
+```
 
--
-Example:
+```
+<edit-config target="NSMicrophoneUsageDescription" file="*-Info.plist" mode="merge">
+    <string>need microphone access to record sounds</string>
+</edit-config>
+```
 
-`cordova plugin add cordova-plugin-media-capture --variable CAMERA_USAGE_DESCRIPTION="your usage message"`
-
-If you don't pass the variable, the plugin will add an empty string as value.
+```
+<edit-config target="NSPhotoLibraryUsageDescription" file="*-Info.plist" mode="merge">
+    <string>need to photo library access to get pictures from there</string>
+</edit-config>
+```
 
 ### Windows Phone 7 Quirks
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -149,21 +149,6 @@ xmlns:rim="http://www.blackberry.com/ns/widgets"
         <framework src="CoreGraphics.framework" />
         <framework src="MobileCoreServices.framework" />
 
-        <preference name="CAMERA_USAGE_DESCRIPTION" default=" " />
-        <config-file target="*-Info.plist" parent="NSCameraUsageDescription">
-            <string>$CAMERA_USAGE_DESCRIPTION</string>
-        </config-file>
-
-        <preference name="MICROPHONE_USAGE_DESCRIPTION" default=" " />
-        <config-file target="*-Info.plist" parent="NSMicrophoneUsageDescription">
-            <string>$MICROPHONE_USAGE_DESCRIPTION</string>
-        </config-file>
-
-        <preference name="PHOTOLIBRARY_USAGE_DESCRIPTION" default=" " />
-        <config-file target="*-Info.plist" parent="NSPhotoLibraryUsageDescription">
-            <string>$PHOTOLIBRARY_USAGE_DESCRIPTION</string>
-        </config-file>
-
     </platform>
 
     <!-- blackberry10 -->


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
iOS

### What does this PR do?
Removes the usage description variables and document how to set them using edit-config tab

### What testing has been done on this change?


### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
