### PR TITLE
GH-102 Catch ActivityNotFoundException

### DIFF
--- a/src/android/Capture.java
+++ b/src/android/Capture.java
@@ -27,6 +27,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 
+import android.content.ActivityNotFoundException;
 import android.os.Build;
 import android.os.Bundle;
 
@@ -75,6 +76,7 @@ public class Capture extends CordovaPlugin {
 //    private static final int CAPTURE_INVALID_ARGUMENT = 2;
     private static final int CAPTURE_NO_MEDIA_FILES = 3;
     private static final int CAPTURE_PERMISSION_DENIED = 4;
+    private static final int CAPTURE_NOT_SUPPORTED = 20;
 
     private boolean cameraPermissionInManifest;     // Whether or not the CAMERA permission is declared in AndroidManifest.xml
 
@@ -229,9 +231,13 @@ public class Capture extends CordovaPlugin {
       if (!PermissionHelper.hasPermission(this, Manifest.permission.READ_EXTERNAL_STORAGE)) {
           PermissionHelper.requestPermission(this, req.requestCode, Manifest.permission.READ_EXTERNAL_STORAGE);
       } else {
-          Intent intent = new Intent(android.provider.MediaStore.Audio.Media.RECORD_SOUND_ACTION);
+          try {
+              Intent intent = new Intent(android.provider.MediaStore.Audio.Media.RECORD_SOUND_ACTION);
 
-          this.cordova.startActivityForResult((CordovaPlugin) this, intent, req.requestCode);
+              this.cordova.startActivityForResult((CordovaPlugin) this, intent, req.requestCode);
+          } catch (ActivityNotFoundException ex) {
+              pendingRequests.resolveWithFailure(req, createErrorObject(CAPTURE_NOT_SUPPORTED, "No Activity found to handle Audio Capture."));
+          }
       }
     }
 


### PR DESCRIPTION
### Platforms affected
Android

### What does this PR do?
Catch ActivityNotFoundException when there is no app that can handle audio capture

Closes #102 

### What testing has been done on this change?
Tested on Android 8 device without capture app

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [ ] Added automated test coverage as appropriate for this change.
