### PR TITLE
(Android) Asking for permission

### DIFF
--- a/src/android/Capture.java
+++ b/src/android/Capture.java
@@ -26,6 +26,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.Arrays;
+import java.util.ArrayList;
 
 import android.content.ActivityNotFoundException;
 import android.os.Build;
@@ -297,8 +298,16 @@ public class Capture extends CordovaPlugin {
      * Sets up an intent to capture video.  Result handled by onActivityResult()
      */
     private void captureVideo(Request req) {
-        if(cameraPermissionInManifest && !PermissionHelper.hasPermission(this, Manifest.permission.CAMERA)) {
-            PermissionHelper.requestPermission(this, req.requestCode, Manifest.permission.CAMERA);
+        ArrayList<String> list = new ArrayList<>();
+        if (!PermissionHelper.hasPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE))
+            list.add(Manifest.permission.WRITE_EXTERNAL_STORAGE);
+        if (cameraPermissionInManifest && !PermissionHelper.hasPermission(this, Manifest.permission.CAMERA))
+            list.add(Manifest.permission.CAMERA);
+        if (!PermissionHelper.hasPermission(this, Manifest.permission.READ_EXTERNAL_STORAGE))
+            list.add(Manifest.permission.READ_EXTERNAL_STORAGE);
+
+        if (list.size() > 0) {
+            PermissionHelper.requestPermissions(this, req.requestCode, list.toArray(new String[list.size()]));
         } else {
             Intent intent = new Intent(android.provider.MediaStore.ACTION_VIDEO_CAPTURE);
 


### PR DESCRIPTION
Asking for camera, read, and write permissions when calling captureVideo

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

https://github.com/apache/cordova-plugin-media-capture/issues/135
https://github.com/apache/cordova-plugin-file/issues/348

### Description
<!-- Describe your changes in detail -->
We capturing a video on Android, the returned mediaFile will not be accessible to the cordova app if read permissions are not requested.  For some reason, the process used to request permissions in captureAudio, captureImage, and captureVideo are all different. I've only addressed the captureVideo issue in this PR. A more consistent approach in all three cases should probably be considered. 


### Testing
<!-- Please describe in detail how you tested your changes. -->
Testing in a demo app to confirm that file access it requested (if needed).


### Checklist

I haven't done all of this yet. Hoping to unblock people that have this same issue

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
