### PR TITLE
Prevent audio recording from getting stuck

### DIFF
--- a/src/ios/CDVCapture.m
+++ b/src/ios/CDVCapture.m
@@ -607,6 +607,7 @@
 @interface CDVAudioRecorderViewController () {
     UIStatusBarStyle _previousStatusBarStyle;
 }
+@property (nonatomic, getter=isModalInPresentation) BOOL modalInPresentation;
 @end
 
 @implementation CDVAudioRecorderViewController
@@ -639,6 +640,11 @@
         self.callbackId = theCallbackId;
         self.errorCode = CAPTURE_NO_MEDIA_FILES;
         self.isTimed = self.duration != nil;
+
+        if (@available(iOS 13, *)) {
+            self.modalInPresentation = YES;
+        }
+
         _previousStatusBarStyle = [UIApplication sharedApplication].statusBarStyle;
 
         return self;


### PR DESCRIPTION
Swiping away the recording modal on iOS 13 causes the plugin

* to never stop in the background
* never to call any callback
* to prevent you from starting another recording

This commit disables the swiping action.

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

iOS

### Motivation and Context

This is a temporary fix to avoid https://github.com/apache/cordova-plugin-media-capture/issues/151

### Description

Using the `isModalInPresentation` prop of the UIViewController, I've disable the swiping action.

### Testing

This has only been tested on an iOS 13 iPhone 6S. The test was to try and dismiss the recording modal with  a swipe. The recording modal was opened by running

```js
navigator.device.capture.captureAudio();
```

in a javascript console.



### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
