### PR TITLE
Fix video capture crashing on save

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-media-capture",
-  "version": "3.0.2",
+  "version": "3.0.2-j5.1",
   "description": "Cordova Media Capture Plugin",
   "types": "./types/index.d.ts",
   "cordova": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-media-capture",
-  "version": "3.0.2-j5.1",
+  "version": "3.0.2",
   "description": "Cordova Media Capture Plugin",
   "types": "./types/index.d.ts",
   "cordova": {

--- a/plugin.xml
+++ b/plugin.xml
@@ -22,7 +22,7 @@
 xmlns:android="http://schemas.android.com/apk/res/android"
 xmlns:rim="http://www.blackberry.com/ns/widgets"
            id="cordova-plugin-media-capture"
-      version="3.0.2">
+      version="3.0.2-j5.1">
     <name>Capture</name>
 
     <description>Cordova Media Capture Plugin</description>

--- a/plugin.xml
+++ b/plugin.xml
@@ -22,7 +22,7 @@
 xmlns:android="http://schemas.android.com/apk/res/android"
 xmlns:rim="http://www.blackberry.com/ns/widgets"
            id="cordova-plugin-media-capture"
-      version="3.0.2-j5.1">
+      version="3.0.2">
     <name>Capture</name>
 
     <description>Cordova Media Capture Plugin</description>

--- a/src/android/Capture.java
+++ b/src/android/Capture.java
@@ -339,9 +339,9 @@ public class Capture extends CordovaPlugin {
                 }
                 this.cordova.startActivityForResult((CordovaPlugin) this, intent, req.requestCode);
             } catch (InterruptedException e) {
-                System.out.println("Thread interrupted while creating path for new video: \n"+e.getMessage());
+                LOG.e(LOG_TAG, "Thread interrupted while creating path for new video: \n"+e.getMessage());
             } catch (ExecutionException e) {
-                System.out.println("Exception raised while creating folder for new video: \n" +e.getMessage());
+                LOG.e(LOG_TAG, "Exception raised while creating folder for new video: \n" +e.getMessage());
             }
         }
     }

--- a/src/android/Capture.java
+++ b/src/android/Capture.java
@@ -77,6 +77,7 @@ public class Capture extends CordovaPlugin {
 //    private static final int CAPTURE_INVALID_ARGUMENT = 2;
     private static final int CAPTURE_NO_MEDIA_FILES = 3;
     private static final int CAPTURE_PERMISSION_DENIED = 4;
+    private static final int CANNOT_CREATE_TARGET_DIRECTORY = 5;
 
     private boolean cameraPermissionInManifest;     // Whether or not the CAMERA permission is declared in AndroidManifest.xml
 
@@ -339,9 +340,9 @@ public class Capture extends CordovaPlugin {
                 }
                 this.cordova.startActivityForResult((CordovaPlugin) this, intent, req.requestCode);
             } catch (InterruptedException e) {
-                LOG.e(LOG_TAG, "Thread interrupted while creating path for new video: \n"+e.getMessage());
+                pendingRequests.resolveWithFailure(req, createErrorObject(CANNOT_CREATE_TARGET_DIRECTORY, "Thread interrupted while creating path for new video"));
             } catch (ExecutionException e) {
-                LOG.e(LOG_TAG, "Exception raised while creating folder for new video: \n" +e.getMessage());
+                pendingRequests.resolveWithFailure(req, createErrorObject(CANNOT_CREATE_TARGET_DIRECTORY, "Exception raised while creating folder for new video"));
             }
         }
     }

--- a/src/android/Capture.java
+++ b/src/android/Capture.java
@@ -316,8 +316,10 @@ public class Capture extends CordovaPlugin {
             Intent intent = new Intent(android.provider.MediaStore.ACTION_VIDEO_CAPTURE);
 
             final ContentResolver contentResolver = this.cordova.getActivity().getContentResolver();
-            final ContentValues cv = new ContentValues();
-            cv.put(MediaStore.Images.Media.MIME_TYPE, VIDEO_MP4); // 3gp in some cases?
+            final ContentValues contentValues = new ContentValues();
+            contentValues.put(MediaStore.Images.Media.MIME_TYPE, VIDEO_MP4); // 3gp in some cases?
+            LOG.d(LOG_TAG, "Taking a video and saving to: " + videoUri.toString());
+
             try {
                 cordova.getThreadPool().submit(new Runnable() {
                     @Override

--- a/src/android/Capture.java
+++ b/src/android/Capture.java
@@ -318,7 +318,6 @@ public class Capture extends CordovaPlugin {
             final ContentResolver contentResolver = this.cordova.getActivity().getContentResolver();
             final ContentValues contentValues = new ContentValues();
             contentValues.put(MediaStore.Images.Media.MIME_TYPE, VIDEO_MP4); // 3gp in some cases?
-            LOG.d(LOG_TAG, "Taking a video and saving to: " + videoUri.toString());
 
             try {
                 cordova.getThreadPool().submit(new Runnable() {
@@ -331,7 +330,7 @@ public class Capture extends CordovaPlugin {
                         }
                     }
                 }).get(); // get() blocks the thread
-
+		LOG.d(LOG_TAG, "Taking a video and saving to: " + videoUri.toString());
                 intent.putExtra(android.provider.MediaStore.EXTRA_OUTPUT, videoUri);
 
                 if(Build.VERSION.SDK_INT > 7){

--- a/src/android/Capture.java
+++ b/src/android/Capture.java
@@ -27,6 +27,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.concurrent.ExecutionException;
 
 import android.os.Build;
 import android.os.Bundle;
@@ -313,8 +314,8 @@ public class Capture extends CordovaPlugin {
         } else {
             Intent intent = new Intent(android.provider.MediaStore.ACTION_VIDEO_CAPTURE);
 
-            ContentResolver contentResolver = this.cordova.getActivity().getContentResolver();
-            ContentValues cv = new ContentValues();
+            final ContentResolver contentResolver = this.cordova.getActivity().getContentResolver();
+            final ContentValues cv = new ContentValues();
             cv.put(MediaStore.Images.Media.MIME_TYPE, VIDEO_MP4); // 3gp in some cases?
             try {
                 cordova.getThreadPool().submit(new Runnable() {


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
Saving a video using a Samsung Galaxy Tab A (model number SM-T295) generated an uncaught exception because the URI retrieved from the intent could not be resolved.
<!-- If it fixes an open issue, please link to the issue here. -->



### Description
<!-- Describe your changes in detail -->
Instead of getting the URI from the intent, I took the same approach currently used with images - get a URI from the ContentResolver before capturing the video and save that in a global variable which is read when processing the result.

I found that this change caused an issue with another device because the directories specified by the URI don't seem to be guaranteed to exist - so I added some logic to create the folders when that occurs.

### Testing
<!-- Please describe in detail how you tested your changes. -->
In progress


### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
