### PR TITLE
(iOS) implement the 'quality' property in captureVideo()

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,6 +354,8 @@ capturing a video clip, the `CaptureErrorCB` callback executes with a
 
 - __duration__: The maximum duration of a video clip, in seconds.
 
+- __quality__: The quality of the captured video. A value of `1` ( the default ) means high quality and value of `0` means low quality, suitable for MMS messages.
+
 ### Example
 
     // limit capture operation to 3 video clips
@@ -361,20 +363,17 @@ capturing a video clip, the `CaptureErrorCB` callback executes with a
 
     navigator.device.capture.captureVideo(captureSuccess, captureError, options);
 
-### iOS Quirks
-
-- The __limit__ property is ignored.  Only one video is recorded per invocation.
-
-### Android Quirks
-
-- Android supports an additional __quality__ property, to allow capturing video at different qualities.  A value of `1` ( the default ) means high quality and value of `0` means low quality, suitable for MMS messages.
-  See [here](http://developer.android.com/reference/android/provider/MediaStore.html#EXTRA_VIDEO_QUALITY) for more details.
-
-### Example ( Android w/ quality )
+### Example ( w/ quality )
 
     // limit capture operation to 1 video clip of low quality
     var options = { limit: 1, quality: 0 };
     navigator.device.capture.captureVideo(captureSuccess, captureError, options);
+
+### iOS Quirks
+
+- The __limit__ property is ignored.  Only one video is recorded per invocation.
+
+- The __quality__ property has an additional value of `0.5` for Medium quality. 
 
 
 ## CaptureCB

--- a/src/ios/CDVCapture.m
+++ b/src/ios/CDVCapture.m
@@ -224,6 +224,7 @@
     // taking more than one video (limit) is only supported if provide own controls via cameraOverlayView property
     NSNumber* duration = [options objectForKey:@"duration"];
     NSString* mediaType = nil;
+	NSNumber* quality = [options objectForKey:@"quality"];
 
     if ([UIImagePickerController isSourceTypeAvailable:UIImagePickerControllerSourceTypeCamera]) {
         // there is a camera, it is available, make sure it can do movies

--- a/src/ios/CDVCapture.m
+++ b/src/ios/CDVCapture.m
@@ -271,11 +271,11 @@
                 case 0: 
                     pickerController.videoQuality = UIImagePickerControllerQualityTypeLow;
                     break;
-                case 10: 
-                    pickerController.videoQuality = UIImagePickerControllerQualityTypeHigh;
+                case 5: 
+                    pickerController.videoQuality = UIImagePickerControllerQualityTypeMedium;
                     break;
                 default:
-                    pickerController.videoQuality = UIImagePickerControllerQualityTypeMedium;
+                    pickerController.videoQuality = UIImagePickerControllerQualityTypeHigh;
                     break;
                 }    
 	        // pickerController.videoQuality = UIImagePickerControllerQualityTypeHigh;

--- a/src/ios/CDVCapture.m
+++ b/src/ios/CDVCapture.m
@@ -220,7 +220,7 @@
         options = [NSDictionary dictionary];
     }
 
-    // options could contain limit, duration and mode
+    // options could contain limit, duration, quality, and mode
     // taking more than one video (limit) is only supported if provide own controls via cameraOverlayView property
     NSNumber* duration = [options objectForKey:@"duration"];
     NSString* mediaType = nil;
@@ -266,7 +266,18 @@
         // iOS 4.0
         if ([pickerController respondsToSelector:@selector(cameraCaptureMode)]) {
             pickerController.cameraCaptureMode = UIImagePickerControllerCameraCaptureModeVideo;
-            // pickerController.videoQuality = UIImagePickerControllerQualityTypeHigh;
+            switch((int)([quality doubleValue]*10)) {
+                case 0: 
+                    pickerController.videoQuality = UIImagePickerControllerQualityTypeLow;
+                    break;
+                case 10: 
+                    pickerController.videoQuality = UIImagePickerControllerQualityTypeHigh;
+                    break;
+                default:
+                    pickerController.videoQuality = UIImagePickerControllerQualityTypeMedium;
+                    break;
+                }    
+	        // pickerController.videoQuality = UIImagePickerControllerQualityTypeHigh;
             // pickerController.cameraDevice = UIImagePickerControllerCameraDeviceRear;
             // pickerController.cameraFlashMode = UIImagePickerControllerCameraFlashModeAuto;
         }

--- a/src/ios/CDVCapture.m
+++ b/src/ios/CDVCapture.m
@@ -224,7 +224,7 @@
     // taking more than one video (limit) is only supported if provide own controls via cameraOverlayView property
     NSNumber* duration = [options objectForKey:@"duration"];
     NSString* mediaType = nil;
-	NSNumber* quality = [options objectForKey:@"quality"];
+    NSNumber* quality = [options objectForKey:@"quality"];
 
     if ([UIImagePickerController isSourceTypeAvailable:UIImagePickerControllerSourceTypeCamera]) {
         // there is a camera, it is available, make sure it can do movies


### PR DESCRIPTION
### Platforms affected
iOS


### Motivation and Context
iOS 13 records video at 360p
https://forum.ionicframework.com/t/media-capture-video-is-low-quality/103774/24



### Description
@maxpaj made the changes @jcesarmobile asked for in #48 and #65, but I did not see a pull request so I updated the documentation and am submitting his fix.



### Checklist

- [x] I've run the tests to see all new and existing tests pass
https://github.com/apache/cordova-plugin-media-capture/pull/65#issuecomment-306416412
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] I've updated the documentation if necessary
