### PR TITLE
(browser) Closes #149 Image capture not working on Chrome browser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,8 @@ Thumbs.db
 
 node_modules
 
-
+/.idea
+/package-lock.json
 
 
 


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

browser

### Motivation and Context

https://github.com/apache/cordova-plugin-media-capture/issues/149

### Description

Fixes the problem described in the mentioned issue and a couple of other related issues encountered while trying to get capture image to work.

### Testing

Chrome: Version 81.0.4044.92 (Official Build) (64-bit) Linux Ubuntu 18.04
Chromium: Version 80.0.3987.163 (Official Build) Built on Ubuntu , running on Ubuntu 18.04 (64-bit)
Firefox: 75 (64bit) Linux (Ubuntu 18.04 64bit)

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
