### PR TITLE
fix(ios): UI sizing of the audio capture controller according to parent view size

### DIFF
--- a/src/ios/CDVCapture.m
+++ b/src/ios/CDVCapture.m
@@ -647,86 +647,6 @@
     return nil;
 }
 
-- (void)loadView
-{
-	if ([self respondsToSelector:@selector(edgesForExtendedLayout)]) {
-        self.edgesForExtendedLayout = UIRectEdgeNone;
-    }
-
-    // create view and display
-    CGRect viewRect = [[UIScreen mainScreen] applicationFrame];
-    UIView* tmp = [[UIView alloc] initWithFrame:viewRect];
-
-    // make backgrounds
-    NSString* microphoneResource = @"CDVCapture.bundle/microphone";
-
-    BOOL isIphone5 = ([[UIScreen mainScreen] bounds].size.width == 568 && [[UIScreen mainScreen] bounds].size.height == 320) || ([[UIScreen mainScreen] bounds].size.height == 568 && [[UIScreen mainScreen] bounds].size.width == 320);
-    if (isIphone5) {
-        microphoneResource = @"CDVCapture.bundle/microphone-568h";
-    }
-
-    NSBundle* cdvBundle = [NSBundle bundleForClass:[CDVCapture class]];
-    UIImage* microphone = [UIImage imageNamed:[self resolveImageResource:microphoneResource] inBundle:cdvBundle compatibleWithTraitCollection:nil];
-    UIView* microphoneView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, viewRect.size.width, microphone.size.height)];
-    [microphoneView setBackgroundColor:[UIColor colorWithPatternImage:microphone]];
-    [microphoneView setUserInteractionEnabled:NO];
-    [microphoneView setIsAccessibilityElement:NO];
-    [tmp addSubview:microphoneView];
-
-    // add bottom bar view
-    UIImage* grayBkg = [UIImage imageNamed:[self resolveImageResource:@"CDVCapture.bundle/controls_bg"] inBundle:cdvBundle compatibleWithTraitCollection:nil];
-    UIView* controls = [[UIView alloc] initWithFrame:CGRectMake(0, microphone.size.height, viewRect.size.width, grayBkg.size.height)];
-    [controls setBackgroundColor:[UIColor colorWithPatternImage:grayBkg]];
-    [controls setUserInteractionEnabled:NO];
-    [controls setIsAccessibilityElement:NO];
-    [tmp addSubview:controls];
-
-    // make red recording background view
-    UIImage* recordingBkg = [UIImage imageNamed:[self resolveImageResource:@"CDVCapture.bundle/recording_bg"] inBundle:cdvBundle compatibleWithTraitCollection:nil];
-    UIColor* background = [UIColor colorWithPatternImage:recordingBkg];
-    self.recordingView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, viewRect.size.width, recordingBkg.size.height)];
-    [self.recordingView setBackgroundColor:background];
-    [self.recordingView setHidden:YES];
-    [self.recordingView setUserInteractionEnabled:NO];
-    [self.recordingView setIsAccessibilityElement:NO];
-    [tmp addSubview:self.recordingView];
-
-    // add label
-    self.timerLabel = [[UILabel alloc] initWithFrame:CGRectMake(0, 0, viewRect.size.width, recordingBkg.size.height)];
-    // timerLabel.autoresizingMask = reSizeMask;
-    [self.timerLabel setBackgroundColor:[UIColor clearColor]];
-    [self.timerLabel setTextColor:[UIColor whiteColor]];
-#ifdef __IPHONE_6_0
-    [self.timerLabel setTextAlignment:NSTextAlignmentCenter];
-#else
-    // for iOS SDK < 6.0
-    [self.timerLabel setTextAlignment:UITextAlignmentCenter];
-#endif
-    [self.timerLabel setText:@"0:00"];
-    [self.timerLabel setAccessibilityHint:PluginLocalizedString(captureCommand, @"recorded time in minutes and seconds", nil)];
-    self.timerLabel.accessibilityTraits |= UIAccessibilityTraitUpdatesFrequently;
-    self.timerLabel.accessibilityTraits &= ~UIAccessibilityTraitStaticText;
-    [tmp addSubview:self.timerLabel];
-
-    // Add record button
-
-    self.recordImage = [UIImage imageNamed:[self resolveImageResource:@"CDVCapture.bundle/record_button"] inBundle:cdvBundle compatibleWithTraitCollection:nil];
-    self.stopRecordImage = [UIImage imageNamed:[self resolveImageResource:@"CDVCapture.bundle/stop_button"] inBundle:cdvBundle compatibleWithTraitCollection:nil];
-    self.recordButton.accessibilityTraits |= [self accessibilityTraits];
-    self.recordButton = [[UIButton alloc] initWithFrame:CGRectMake((viewRect.size.width - recordImage.size.width) / 2, (microphone.size.height + (grayBkg.size.height - recordImage.size.height) / 2), recordImage.size.width, recordImage.size.height)];
-    [self.recordButton setAccessibilityLabel:PluginLocalizedString(captureCommand, @"toggle audio recording", nil)];
-    [self.recordButton setImage:recordImage forState:UIControlStateNormal];
-    [self.recordButton addTarget:self action:@selector(processButton:) forControlEvents:UIControlEventTouchUpInside];
-    [tmp addSubview:recordButton];
-
-    // make and add done button to navigation bar
-    self.doneButton = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone target:self action:@selector(dismissAudioView:)];
-    [self.doneButton setStyle:UIBarButtonItemStyleDone];
-    self.navigationItem.rightBarButtonItem = self.doneButton;
-
-    [self setView:tmp];
-}
-
 - (void)viewDidLoad
 {
     [super viewDidLoad];
@@ -774,6 +694,79 @@
         self.recordButton.enabled = YES;
         self.doneButton.enabled = YES;
     }
+}
+
+-(void) setupUI {
+
+    CGRect viewRect = self.view.bounds;
+    CGFloat topInset = self.navigationController.navigationBar.frame.size.height;
+    CGFloat bottomInset = 10;
+
+    // make backgrounds
+    NSString* microphoneResource = @"CDVCapture.bundle/microphone";
+
+    BOOL isIphone5 = ([[UIScreen mainScreen] bounds].size.width == 568 && [[UIScreen mainScreen] bounds].size.height == 320) || ([[UIScreen mainScreen] bounds].size.height == 568 && [[UIScreen mainScreen] bounds].size.width == 320);
+    if (isIphone5) {
+        microphoneResource = @"CDVCapture.bundle/microphone-568h";
+    }
+
+    NSBundle* cdvBundle = [NSBundle bundleForClass:[CDVCapture class]];
+    UIImage* microphone = [UIImage imageNamed:[self resolveImageResource:microphoneResource] inBundle:cdvBundle compatibleWithTraitCollection:nil];
+    UIImageView* microphoneView = [[UIImageView alloc] initWithFrame:CGRectMake(0, 0, viewRect.size.width, viewRect.size.height)];
+    [microphoneView setImage:microphone];
+    [microphoneView setContentMode:UIViewContentModeScaleAspectFill];
+    [microphoneView setUserInteractionEnabled:NO];
+    [microphoneView setIsAccessibilityElement:NO];
+    [self.view addSubview:microphoneView];
+
+    // add bottom bar view
+    UIImage* grayBkg = [UIImage imageNamed:[self resolveImageResource:@"CDVCapture.bundle/controls_bg"] inBundle:cdvBundle compatibleWithTraitCollection:nil];
+    UIImageView* controls = [[UIImageView alloc] initWithFrame:CGRectMake(0, viewRect.size.height - grayBkg.size.height - bottomInset,
+                                                                          viewRect.size.width, grayBkg.size.height + bottomInset)];
+    [controls setImage:grayBkg];
+    [controls setUserInteractionEnabled:NO];
+    [controls setIsAccessibilityElement:NO];
+    [self.view addSubview:controls];
+
+    // make red recording background view
+    UIImage* recordingBkg = [UIImage imageNamed:[self resolveImageResource:@"CDVCapture.bundle/recording_bg"] inBundle:cdvBundle compatibleWithTraitCollection:nil];
+    UIColor* background = [UIColor colorWithPatternImage:recordingBkg];
+    self.recordingView = [[UIView alloc] initWithFrame:CGRectMake(0, topInset, viewRect.size.width, recordingBkg.size.height)];
+    [self.recordingView setBackgroundColor:background];
+    [self.recordingView setHidden:YES];
+    [self.recordingView setUserInteractionEnabled:NO];
+    [self.recordingView setIsAccessibilityElement:NO];
+    [self.view addSubview:self.recordingView];
+
+    // add label
+    self.timerLabel = [[UILabel alloc] initWithFrame:CGRectMake(0, topInset, viewRect.size.width, recordingBkg.size.height)];
+    [self.timerLabel setBackgroundColor:[UIColor clearColor]];
+    [self.timerLabel setTextColor:[UIColor whiteColor]];
+    [self.timerLabel setTextAlignment:NSTextAlignmentCenter];
+    [self.timerLabel setText:@"0:00"];
+    [self.timerLabel setAccessibilityHint:PluginLocalizedString(captureCommand, @"recorded time in minutes and seconds", nil)];
+    self.timerLabel.accessibilityTraits |= UIAccessibilityTraitUpdatesFrequently;
+    self.timerLabel.accessibilityTraits &= ~UIAccessibilityTraitStaticText;
+    [self.view addSubview:self.timerLabel];
+
+    // Add record button
+
+    self.recordImage = [UIImage imageNamed:[self resolveImageResource:@"CDVCapture.bundle/record_button"] inBundle:cdvBundle compatibleWithTraitCollection:nil];
+    self.stopRecordImage = [UIImage imageNamed:[self resolveImageResource:@"CDVCapture.bundle/stop_button"] inBundle:cdvBundle compatibleWithTraitCollection:nil];
+    self.recordButton.accessibilityTraits |= [self accessibilityTraits];
+    self.recordButton = [[UIButton alloc] initWithFrame:CGRectMake((viewRect.size.width - self.recordImage.size.width) / 2,
+                                                                   microphoneView.frame.size.height - bottomInset - grayBkg.size.height +
+                                                                    ((grayBkg.size.height - self.recordImage.size.height) / 2),
+                                                                   self.recordImage.size.width, self.recordImage.size.height)];
+    [self.recordButton setAccessibilityLabel:PluginLocalizedString(captureCommand, @"toggle audio recording", nil)];
+    [self.recordButton setImage:recordImage forState:UIControlStateNormal];
+    [self.recordButton addTarget:self action:@selector(processButton:) forControlEvents:UIControlEventTouchUpInside];
+    [self.view addSubview:recordButton];
+
+    // make and add done button to navigation bar
+    self.doneButton = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone target:self action:@selector(dismissAudioView:)];
+    [self.doneButton setStyle:UIBarButtonItemStyleDone];
+    self.navigationItem.rightBarButtonItem = self.doneButton;
 }
 
 #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 90000
@@ -974,6 +967,8 @@
     }
 
     [super viewWillAppear:animated];
+
+    [self setupUI];
 }
 
 @end


### PR DESCRIPTION
Fixed UI sizing for audio capture controller according to parent view size

### Platforms affected
iOS


### Motivation and Context
Audio capture controller's view looks different for iPhones and iPads and crops according to the device size.
![1](https://user-images.githubusercontent.com/35519010/89027170-3f3e9100-d354-11ea-9556-a824a6d4e3b8.jpg)
![2](https://user-images.githubusercontent.com/35519010/89027217-4fef0700-d354-11ea-80eb-ca75eef61cb5.jpg)


### Description
I changed the size calculation for the audio capture controller's layout. Now the UI looks good on all devices.
![3](https://user-images.githubusercontent.com/35519010/89027260-6301d700-d354-11ea-9e3a-e040cf02459a.jpg)


### Testing
I didn’t find any tests for this plugin.


### Checklist

- [X] I've run the tests to see all new and existing tests pass
- [X] I added automated test coverage as appropriate for this change
- [X] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [X] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [X] I've updated the documentation if necessary
