### PR TITLE
fix(ios): CAPTURE_APPLICATION_BUSY error when dismissing modal by swipe

### DIFF
--- a/src/ios/CDVCapture.m
+++ b/src/ios/CDVCapture.m
@@ -604,7 +604,7 @@
 
 @end
 
-@interface CDVAudioRecorderViewController () {
+@interface CDVAudioRecorderViewController () <UIAdaptivePresentationControllerDelegate> {
     UIStatusBarStyle _previousStatusBarStyle;
 }
 @end
@@ -732,6 +732,9 @@
     [super viewDidLoad];
     UIAccessibilityPostNotification(UIAccessibilityScreenChangedNotification, nil);
     NSError* error = nil;
+
+    // Add delegate to catch the dismiss event
+    self.navigationController.presentationController.delegate = self;
 
     if (self.avSession == nil) {
         // create audio session
@@ -974,6 +977,10 @@
     }
 
     [super viewWillAppear:animated];
+}
+
+- (void)presentationControllerDidDismiss:(UIPresentationController *)presentationController {
+    [self dismissAudioView:nil];
 }
 
 @end


### PR DESCRIPTION
Fix a bug with modal presentation style controller dismissing on iOS 13 and above. For now, only for audio capture controller.

### Platforms affected
iOS 13 and above.


### Motivation and Context
Apple added new feature for modals on iOS 13, they might be dismissed by swipe. Such behavior was not handled, so controller threw `CAPTURE_APPLICATION_BUSY`, on opening new modal.

closes #152
fixes #151

### Description
I added audio capture controller as adaptive controller delegate for itself and implemented the method to handle dismiss event. Then I dismiss the controller correctly, as by tap on the “Done” button.


### Testing
I didn’t find any tests for this plugin.


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
