### PR TITLE
fix(MediaFiles): return missing 'lastModified' and 'end' attributes

### DIFF
--- a/www/helpers.js
+++ b/www/helpers.js
@@ -25,15 +25,15 @@ function wrapMediaFiles (pluginResult) {
     const mediaFiles = [];
     let i;
     for (i = 0; i < pluginResult.length; i++) {
-        const mediaFile = new MediaFile();
-        mediaFile.name = pluginResult[i].name;
-
-        // Backwards compatibility
-        mediaFile.localURL = pluginResult[i].localURL || pluginResult[i].fullPath;
+        const mediaFile = new MediaFile(
+            pluginResult[i].name,
+            // Backwards compatibility
+            pluginResult[i].localURL || pluginResult[i].fullPath,
+            pluginResult[i].type,
+            pluginResult[i].lastModifiedDate,
+            pluginResult[i].size
+        );
         mediaFile.fullPath = pluginResult[i].fullPath;
-        mediaFile.type = pluginResult[i].type;
-        mediaFile.lastModifiedDate = pluginResult[i].lastModifiedDate;
-        mediaFile.size = pluginResult[i].size;
         mediaFiles.push(mediaFile);
     }
     return mediaFiles;


### PR DESCRIPTION
### Platforms affected
www


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Returned MediaFiles objects for captured media are missing `lastModified` (_null_) and `end` (_0_).


### Description
<!-- Describe your changes in detail -->
The [helpers.wrapMediaFiles](https://github.com/ath0mas/cordova-plugin-media-capture/blob/master/www/helpers.js#L28) method is using the MediaFile empty constructor, and attributes are set afterward.
But given [MediaFile constructor](https://github.com/ath0mas/cordova-plugin-media-capture/blob/master/www/MediaFile.js#L36) is simply calling its parent [cordova-plugin-file.File constructor](https://github.com/apache/cordova-plugin-file/blob/master/www/File.js#L31), we can understand that some File attributes will never be redefined properly.

Directly calling the constructor with all the params values resolves this problem in a clean manner.


### Testing
<!-- Please describe in detail how you tested your changes. -->
Returned MediaFiles objects now have correct `lastModified` === `lastModifiedDate`, and `end` === `size`.


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
