### PR TITLE
Android: Remove unknown permission android.permission.RECORD_VIDEO

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -78,7 +78,6 @@ xmlns:android="http://schemas.android.com/apk/res/android"
 
         <config-file target="AndroidManifest.xml" parent="/*">
             <uses-permission android:name="android.permission.RECORD_AUDIO" />
-            <uses-permission android:name="android.permission.RECORD_VIDEO"/>
             <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
             <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
         </config-file>


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Permission `android.permission.RECORD_VIDEO` does [not exist](https://developer.android.com/reference/android/Manifest.permission.html).
Fix #199


### Description
<!-- Describe your changes in detail -->
Also described as a _made-up permission_ in this [SO post](https://stackoverflow.com/questions/37755734/unknown-permission-android-permission-record-video).
Android guides on [audio](https://developer.android.com/guide/topics/media/mediarecorder) and [video](https://developer.android.com/guide/topics/media/camera) recording with MediaRecorder only refer to **RECORD_AUDIO** and some other permissions but never to this one.


### Testing
<!-- Please describe in detail how you tested your changes. -->
build


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
