### PR TITLE
fix: use single version in cordovaDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "license": "Apache-2.0",
   "engines": {
     "cordovaDependencies": {
-      ">=1.4.4": {
+      "1.4.4": {
         "cordova-ios": ">=4.0.0"
       },
       "2.0.0": {


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Package


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Warn logged while adding plugin with verbose option:
```
$ cordova plugin add cordova-plugin-media-capture -d
...
Ignoring invalid version in cordova-plugin-media-capture cordovaDependencies: >=1.4.4 (must be a single version <= latest or an upper bound)
...
```


### Description
<!-- Describe your changes in detail -->
Using single version `1.4.4` is [interpreted](https://cordova.apache.org/docs/en/10.x/guide/hybrid/plugins/index.html#specifying-cordova-dependencies) as _>=1.4.4_ so indeed actual value can be simplified.


### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
