### PR TITLE
feat(ios): support capture 'quality' param for videos

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,7 +363,7 @@ capturing a video clip, the `CaptureErrorCB` callback executes with a
 
 - The __limit__ property is ignored.  Only one video is recorded per invocation.
 
-- iOS supports an additional __quality__ property, to allow capturing video at different qualities.  A value of `0.5` ( the default ) means medium quality, value of `1` means high quality and value of `0` means low quality.
+- iOS supports an additional __quality__ property, to allow capturing video at different qualities.  A value of `1` ( the default ) means high quality, value of `0.5` means medium quality, and value of `0` means low quality.
   See [here](https://developer.apple.com/documentation/uikit/uiimagepickercontroller/1619154-videoquality?language=objc) for more details.
 
 ### Android Quirks

--- a/README.md
+++ b/README.md
@@ -352,6 +352,8 @@ capturing a video clip, the `CaptureErrorCB` callback executes with a
 
 - __duration__: The maximum duration of a video clip, in seconds.
 
+- __quality__: To allow capturing video at different qualities.  A value of `1` ( the default ) means high quality and value of `0` means low quality, suitable for MMS messages.
+
 ### Example
 
     // limit capture operation to 3 video clips
@@ -363,13 +365,13 @@ capturing a video clip, the `CaptureErrorCB` callback executes with a
 
 - The __limit__ property is ignored.  Only one video is recorded per invocation.
 
-- iOS supports an additional __quality__ property, to allow capturing video at different qualities.  A value of `1` ( the default ) means high quality, value of `0.5` means medium quality, and value of `0` means low quality.
-  See [here](https://developer.apple.com/documentation/uikit/uiimagepickercontroller/1619154-videoquality?language=objc) for more details.
+- The __quality__ property can have a value of `0.5` for medium quality.
+
+- See [here](https://developer.apple.com/documentation/uikit/uiimagepickercontroller/1619154-videoquality?language=objc) for more details about the __quality__ property on iOS.
 
 ### Android Quirks
 
-- Android supports an additional __quality__ property, to allow capturing video at different qualities.  A value of `1` ( the default ) means high quality and value of `0` means low quality, suitable for MMS messages.
-  See [here](http://developer.android.com/reference/android/provider/MediaStore.html#EXTRA_VIDEO_QUALITY) for more details.
+- See [here](http://developer.android.com/reference/android/provider/MediaStore.html#EXTRA_VIDEO_QUALITY) for more details about the __quality__ property on Android.
 
 ### Example ( w/ quality )
 

--- a/README.md
+++ b/README.md
@@ -363,12 +363,15 @@ capturing a video clip, the `CaptureErrorCB` callback executes with a
 
 - The __limit__ property is ignored.  Only one video is recorded per invocation.
 
+- iOS supports an additional __quality__ property, to allow capturing video at different qualities.  A value of `0.5` ( the default ) means medium quality, value of `1` means high quality and value of `0` means low quality.
+  See [here](https://developer.apple.com/documentation/uikit/uiimagepickercontroller/1619154-videoquality?language=objc) for more details.
+
 ### Android Quirks
 
 - Android supports an additional __quality__ property, to allow capturing video at different qualities.  A value of `1` ( the default ) means high quality and value of `0` means low quality, suitable for MMS messages.
   See [here](http://developer.android.com/reference/android/provider/MediaStore.html#EXTRA_VIDEO_QUALITY) for more details.
 
-### Example ( Android w/ quality )
+### Example ( w/ quality )
 
     // limit capture operation to 1 video clip of low quality
     var options = { limit: 1, quality: 0 };

--- a/src/ios/CDVCapture.m
+++ b/src/ios/CDVCapture.m
@@ -272,10 +272,10 @@
                     pickerController.videoQuality = UIImagePickerControllerQualityTypeLow;
                     break;
                 case 5:
-                default:
                     pickerController.videoQuality = UIImagePickerControllerQualityTypeMedium;
                     break;
                 case 10:
+                default:
                     pickerController.videoQuality = UIImagePickerControllerQualityTypeHigh;
                     break;
             }

--- a/src/ios/CDVCapture.m
+++ b/src/ios/CDVCapture.m
@@ -220,9 +220,10 @@
         options = [NSDictionary dictionary];
     }
 
-    // options could contain limit, duration and mode
+    // options could contain limit, duration, quality and mode
     // taking more than one video (limit) is only supported if provide own controls via cameraOverlayView property
     NSNumber* duration = [options objectForKey:@"duration"];
+    NSNumber* quality = [options objectForKey:@"quality"];
     NSString* mediaType = nil;
 
     if ([UIImagePickerController isSourceTypeAvailable:UIImagePickerControllerSourceTypeCamera]) {
@@ -266,7 +267,18 @@
         // iOS 4.0
         if ([pickerController respondsToSelector:@selector(cameraCaptureMode)]) {
             pickerController.cameraCaptureMode = UIImagePickerControllerCameraCaptureModeVideo;
-            // pickerController.videoQuality = UIImagePickerControllerQualityTypeHigh;
+            switch ((int) ([quality doubleValue] * 10)) {
+                case 0:
+                    pickerController.videoQuality = UIImagePickerControllerQualityTypeLow;
+                    break;
+                case 5:
+                default:
+                    pickerController.videoQuality = UIImagePickerControllerQualityTypeMedium;
+                    break;
+                case 10:
+                    pickerController.videoQuality = UIImagePickerControllerQualityTypeHigh;
+                    break;
+            }
             // pickerController.cameraDevice = UIImagePickerControllerCameraDeviceRear;
             // pickerController.cameraFlashMode = UIImagePickerControllerCameraFlashModeAuto;
         }

--- a/src/ios/CDVCapture.m
+++ b/src/ios/CDVCapture.m
@@ -267,7 +267,7 @@
         // iOS 4.0
         if ([pickerController respondsToSelector:@selector(cameraCaptureMode)]) {
             pickerController.cameraCaptureMode = UIImagePickerControllerCameraCaptureModeVideo;
-            switch ((int) ([quality doubleValue] * 10)) {
+            switch ((int) (quality ? [quality doubleValue] * 10 : -1)) {
                 case 0:
                     pickerController.videoQuality = UIImagePickerControllerQualityTypeLow;
                     break;

--- a/www/CaptureVideoOptions.js
+++ b/www/CaptureVideoOptions.js
@@ -27,8 +27,6 @@ const CaptureVideoOptions = function () {
     this.limit = 1;
     // Maximum duration of a single video clip in seconds.
     this.duration = 0;
-    // Video quality parameter, 0 means low quality, suitable for MMS messages, and value 1 means high quality.
-    this.quality = 1;
 };
 
 module.exports = CaptureVideoOptions;

--- a/www/CaptureVideoOptions.js
+++ b/www/CaptureVideoOptions.js
@@ -27,6 +27,8 @@ const CaptureVideoOptions = function () {
     this.limit = 1;
     // Maximum duration of a single video clip in seconds.
     this.duration = 0;
+    // Video quality parameter, 0 means low quality, suitable for MMS messages, and value 1 means high quality.
+    this.quality = 1;
 };
 
 module.exports = CaptureVideoOptions;


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
iOS


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Use `quality` param for video capture on iOS too.
Previously no configuration was done about it, meaning that the quality used  for capture was _medium_ as iOS default value.

Here is my suggested implementation based on previous PR #162 by @larrybahr with changes after my review and more tests + aligned default to `1` for iOS as it is for Android.


### Description
<!-- Describe your changes in detail -->
Follow iOS logic about video quality: [doc](https://developer.apple.com/documentation/uikit/uiimagepickercontroller/1619154-videoquality?language=objc)

`quality` value of `0` for [UIImagePickerControllerQualityTypeLow](https://developer.apple.com/documentation/uikit/uiimagepickercontrollerqualitytype/uiimagepickercontrollerqualitytypelow?language=objc), `0.5` for [UIImagePickerControllerQualityTypeMedium](https://developer.apple.com/documentation/uikit/uiimagepickercontrollerqualitytype/uiimagepickercontrollerqualitytypemedium?language=objc), or `1` for [UIImagePickerControllerQualityTypeHigh](https://developer.apple.com/documentation/uikit/uiimagepickercontrollerqualitytype/uiimagepickercontrollerqualitytypehigh?language=objc).

For any other value or when `quality` param is not provided we use ~_UIImagePickerControllerQualityTypeMedium_~ _UIImagePickerControllerQualityTypeHigh_.


### Testing
<!-- Please describe in detail how you tested your changes. -->
Confirmed the _switch-case_ resolution with various `quality` values: 0, 0.5, 1, 2, 'foo', false, undefined, and without any captureOpts.


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
