### PR TITLE
[Android] Store image/audio/video in FileProvider due to Android 11 updates

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -34,7 +34,7 @@ xmlns:android="http://schemas.android.com/apk/res/android"
         <engine name="cordova-android" version=">=6.3.0" />
     </engines>
 
-    <dependency id="cordova-plugin-file" version="^6.0.0" />
+    <dependency id="cordova-plugin-file" version="^7.0.0" />
 
     <js-module src="www/CaptureAudioOptions.js" name="CaptureAudioOptions">
         <clobbers target="CaptureAudioOptions" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -103,6 +103,8 @@ xmlns:android="http://schemas.android.com/apk/res/android"
         <js-module src="www/android/init.js" name="init">
             <runs />
         </js-module>
+        <preference name="ANDROID_SUPPORT_V4_VERSION" default="27.+"/>
+        <framework src="com.android.support:support-v4:$ANDROID_SUPPORT_V4_VERSION"/>
     </platform>
 
     <!-- ios -->

--- a/plugin.xml
+++ b/plugin.xml
@@ -71,6 +71,7 @@ xmlns:android="http://schemas.android.com/apk/res/android"
     <!-- android -->
     <platform name="android">
         <config-file target="res/xml/config.xml" parent="/*">
+            <preference name="AndroidXEnabled" value="true" />
             <feature name="Capture" >
                 <param name="android-package" value="org.apache.cordova.mediacapture.Capture"/>
             </feature>

--- a/plugin.xml
+++ b/plugin.xml
@@ -76,6 +76,18 @@ xmlns:android="http://schemas.android.com/apk/res/android"
             </feature>
         </config-file>
 
+        <config-file target="AndroidManifest.xml" parent="application">
+            <provider
+                android:name="org.apache.cordova.mediacapture.FileProvider"
+                android:authorities="${applicationId}.cordova.plugin.mediacapture.provider"
+                android:exported="false"
+                android:grantUriPermissions="true" >
+                <meta-data
+                    android:name="android.support.FILE_PROVIDER_PATHS"
+                    android:resource="@xml/camera_provider_paths"/>
+            </provider>
+        </config-file>
+
         <config-file target="AndroidManifest.xml" parent="/*">
             <uses-permission android:name="android.permission.RECORD_AUDIO" />
             <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
@@ -85,6 +97,7 @@ xmlns:android="http://schemas.android.com/apk/res/android"
         <source-file src="src/android/Capture.java" target-dir="src/org/apache/cordova/mediacapture" />
         <source-file src="src/android/FileHelper.java" target-dir="src/org/apache/cordova/mediacapture" />
         <source-file src="src/android/PendingRequests.java" target-dir="src/org/apache/cordova/mediacapture" />
+        <source-file src="src/android/FileProvider.java" target-dir="src/org/apache/cordova/mediacapture" />
 
         <js-module src="www/android/init.js" name="init">
             <runs />

--- a/plugin.xml
+++ b/plugin.xml
@@ -71,7 +71,6 @@ xmlns:android="http://schemas.android.com/apk/res/android"
     <!-- android -->
     <platform name="android">
         <config-file target="res/xml/config.xml" parent="/*">
-            <preference name="AndroidXEnabled" value="true" />
             <feature name="Capture" >
                 <param name="android-package" value="org.apache.cordova.mediacapture.Capture"/>
             </feature>
@@ -104,9 +103,9 @@ xmlns:android="http://schemas.android.com/apk/res/android"
         <js-module src="www/android/init.js" name="init">
             <runs />
         </js-module>
-        <preference name="ANDROIDX_VERSION" default="1.+" />
-        <framework src="androidx.legacy:legacy-support-v4:$ANDROIDX_VERSION" />
-        <framework src="androidx.appcompat:appcompat:$ANDROIDX_VERSION" />
+        <preference name="ANDROID_SUPPORT_V4_VERSION" default="27.+"/>
+        <framework src="com.android.support:support-v4:$ANDROID_SUPPORT_V4_VERSION"/>
+
     </platform>
 
     <!-- ios -->

--- a/plugin.xml
+++ b/plugin.xml
@@ -103,8 +103,9 @@ xmlns:android="http://schemas.android.com/apk/res/android"
         <js-module src="www/android/init.js" name="init">
             <runs />
         </js-module>
-        <preference name="ANDROID_SUPPORT_V4_VERSION" default="27.+"/>
-        <framework src="com.android.support:support-v4:$ANDROID_SUPPORT_V4_VERSION"/>
+        <preference name="ANDROIDX_VERSION" default="1.+" />
+        <framework src="androidx.legacy:legacy-support-v4:$ANDROIDX_VERSION" />
+        <framework src="androidx.appcompat:appcompat:$ANDROIDX_VERSION" />
     </platform>
 
     <!-- ios -->

--- a/plugin.xml
+++ b/plugin.xml
@@ -84,7 +84,7 @@ xmlns:android="http://schemas.android.com/apk/res/android"
                 android:grantUriPermissions="true" >
                 <meta-data
                     android:name="android.support.FILE_PROVIDER_PATHS"
-                    android:resource="@xml/camera_provider_paths"/>
+                    android:resource="@xml/mediacapture_provider_paths"/>
             </provider>
         </config-file>
 
@@ -98,6 +98,7 @@ xmlns:android="http://schemas.android.com/apk/res/android"
         <source-file src="src/android/FileHelper.java" target-dir="src/org/apache/cordova/mediacapture" />
         <source-file src="src/android/PendingRequests.java" target-dir="src/org/apache/cordova/mediacapture" />
         <source-file src="src/android/FileProvider.java" target-dir="src/org/apache/cordova/mediacapture" />
+        <source-file src="src/android/xml/mediacapture_provider_paths.xml" target-dir="res/xml" />
 
         <js-module src="www/android/init.js" name="init">
             <runs />

--- a/src/android/Capture.java
+++ b/src/android/Capture.java
@@ -59,7 +59,7 @@ import android.media.MediaPlayer;
 import android.net.Uri;
 import android.os.Environment;
 import android.provider.MediaStore;
-import android.support.v4.content.FileProvider;
+import androidx.core.content.FileProvider;
 import org.apache.cordova.BuildHelper;
 
 public class Capture extends CordovaPlugin {

--- a/src/android/Capture.java
+++ b/src/android/Capture.java
@@ -59,7 +59,7 @@ import android.media.MediaPlayer;
 import android.net.Uri;
 import android.os.Environment;
 import android.provider.MediaStore;
-import androidx.core.content.FileProvider;
+import android.support.v4.content.FileProvider;
 import org.apache.cordova.BuildHelper;
 
 public class Capture extends CordovaPlugin {

--- a/src/android/Capture.java
+++ b/src/android/Capture.java
@@ -25,7 +25,9 @@ import java.io.OutputStream;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.text.SimpleDateFormat;
 import java.util.Arrays;
+import java.util.Date;
 
 import android.content.ActivityNotFoundException;
 import android.os.Build;
@@ -57,6 +59,8 @@ import android.media.MediaPlayer;
 import android.net.Uri;
 import android.os.Environment;
 import android.provider.MediaStore;
+import androidx.core.content.FileProvider;
+import org.apache.cordova.BuildHelper;
 
 public class Capture extends CordovaPlugin {
 
@@ -83,7 +87,12 @@ public class Capture extends CordovaPlugin {
     private final PendingRequests pendingRequests = new PendingRequests();
 
     private int numPics;                            // Number of pictures before capture activity
-    private Uri imageUri;
+    private String audioAbsolutePath;
+    private String imageAbsolutePath;
+    private String videoAbsolutePath;
+
+    private String applicationId;
+
 
 //    public void setContext(Context mCtx)
 //    {
@@ -122,6 +131,9 @@ public class Capture extends CordovaPlugin {
 
     @Override
     public boolean execute(String action, JSONArray args, CallbackContext callbackContext) throws JSONException {
+        this.applicationId = (String) BuildHelper.getBuildConfigValue(this.cordova.getActivity(), "APPLICATION_ID");
+        this.applicationId = preferences.getString("applicationId", this.applicationId);
+
         if (action.equals("getFormatData")) {
             JSONObject obj = getFormatData(args.getString(0), args.getString(1));
             callbackContext.success(obj);
@@ -234,6 +246,17 @@ public class Capture extends CordovaPlugin {
           try {
               Intent intent = new Intent(android.provider.MediaStore.Audio.Media.RECORD_SOUND_ACTION);
 
+              String timeStamp = new SimpleDateFormat("yyyyMMddHHmmssSSS").format(new Date());
+              String fileName = "AUDIO_" + timeStamp + ".wav";
+              File audio = new File(getTempDirectoryPath(), fileName);
+
+              Uri audioUri = FileProvider.getUriForFile(this.cordova.getActivity(),
+                      this.applicationId + ".cordova.plugin.mediacapture.provider",
+                      audio);
+              this.audioAbsolutePath = audio.getAbsolutePath();
+              intent.putExtra(android.provider.MediaStore.EXTRA_OUTPUT, audioUri);
+              intent.addFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
+              LOG.d(LOG_TAG, "Recording an audio and saving to: " + this.audioAbsolutePath);
               this.cordova.startActivityForResult((CordovaPlugin) this, intent, req.requestCode);
           } catch (ActivityNotFoundException ex) {
               pendingRequests.resolveWithFailure(req, createErrorObject(CAPTURE_NOT_SUPPORTED, "No Activity found to handle Audio Capture."));
@@ -276,13 +299,17 @@ public class Capture extends CordovaPlugin {
 
             Intent intent = new Intent(android.provider.MediaStore.ACTION_IMAGE_CAPTURE);
 
-            ContentResolver contentResolver = this.cordova.getActivity().getContentResolver();
-            ContentValues cv = new ContentValues();
-            cv.put(MediaStore.Images.Media.MIME_TYPE, IMAGE_JPEG);
-            imageUri = contentResolver.insert(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, cv);
-            LOG.d(LOG_TAG, "Taking a picture and saving to: " + imageUri.toString());
+            String timeStamp = new SimpleDateFormat("yyyyMMddHHmmssSSS").format(new Date());
+            String fileName = "IMG_" + timeStamp + ".jpg";
+            File image = new File(getTempDirectoryPath(), fileName);
 
+            Uri imageUri = FileProvider.getUriForFile(this.cordova.getActivity(),
+                    this.applicationId + ".cordova.plugin.mediacapture.provider",
+                    image);
+            this.imageAbsolutePath = image.getAbsolutePath();
             intent.putExtra(android.provider.MediaStore.EXTRA_OUTPUT, imageUri);
+            intent.addFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
+            LOG.d(LOG_TAG, "Taking a picture and saving to: " + this.imageAbsolutePath);
 
             this.cordova.startActivityForResult((CordovaPlugin) this, intent, req.requestCode);
         }
@@ -301,6 +328,16 @@ public class Capture extends CordovaPlugin {
             PermissionHelper.requestPermission(this, req.requestCode, Manifest.permission.CAMERA);
         } else {
             Intent intent = new Intent(android.provider.MediaStore.ACTION_VIDEO_CAPTURE);
+            String timeStamp = new SimpleDateFormat("yyyyMMddHHmmssSSS").format(new Date());
+            String fileName = "VID_" + timeStamp + ".avi";
+            File movie = new File(getTempDirectoryPath(), fileName);
+
+            Uri videoUri = FileProvider.getUriForFile(this.cordova.getActivity(),
+                    this.applicationId + ".cordova.plugin.mediacapture.provider",
+                    movie);
+            this.videoAbsolutePath = movie.getAbsolutePath();
+            intent.putExtra(android.provider.MediaStore.EXTRA_OUTPUT, videoUri);
+            intent.addFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
 
             if(Build.VERSION.SDK_INT > 7){
                 intent.putExtra("android.intent.extra.durationLimit", req.duration);
@@ -369,10 +406,8 @@ public class Capture extends CordovaPlugin {
 
 
     public void onAudioActivityResult(Request req, Intent intent) {
-        // Get the uri of the audio clip
-        Uri data = intent.getData();
-        // create a file object from the uri
-        req.results.put(createMediaFile(data));
+        // create a file object from the audio absolute path
+        req.results.put(createMediaFileWithAbsolutePath(this.audioAbsolutePath));
 
         if (req.results.length() >= req.limit) {
             // Send Uri back to JavaScript for listening to audio
@@ -385,9 +420,7 @@ public class Capture extends CordovaPlugin {
 
     public void onImageActivityResult(Request req) {
         // Add image to results
-        req.results.put(createMediaFile(imageUri));
-
-        checkForDuplicateImage();
+        req.results.put(createMediaFileWithAbsolutePath(this.imageAbsolutePath));
 
         if (req.results.length() >= req.limit) {
             // Send Uri back to JavaScript for viewing image
@@ -399,32 +432,18 @@ public class Capture extends CordovaPlugin {
     }
 
     public void onVideoActivityResult(Request req, Intent intent) {
-        Uri data = null;
-
-        if (intent != null){
-            // Get the uri of the video clip
-            data = intent.getData();
-        }
-
-        if( data == null){
-            File movie = new File(getTempDirectoryPath(), "Capture.avi");
-            data = Uri.fromFile(movie);
-        }
-
-        // create a file object from the uri
-        if(data == null) {
+        if(this.videoAbsolutePath != null) {
+            req.results.put(createMediaFileWithAbsolutePath(this.videoAbsolutePath));
+        } else {
             pendingRequests.resolveWithFailure(req, createErrorObject(CAPTURE_NO_MEDIA_FILES, "Error: data is null"));
         }
-        else {
-            req.results.put(createMediaFile(data));
 
-            if (req.results.length() >= req.limit) {
-                // Send Uri back to JavaScript for viewing video
-                pendingRequests.resolveWithSuccess(req);
-            } else {
-                // still need to capture more video clips
-                captureVideo(req);
-            }
+        if (req.results.length() >= req.limit) {
+            // Send Uri back to JavaScript for viewing video
+            pendingRequests.resolveWithSuccess(req);
+        } else {
+            // still need to capture more videos
+            captureVideo(req);
         }
     }
 
@@ -475,6 +494,62 @@ public class Capture extends CordovaPlugin {
                 } else {
                     obj.put("type", VIDEO_3GPP);
                 }
+            } else {
+                obj.put("type", FileHelper.getMimeType(Uri.fromFile(fp), cordova));
+            }
+
+            obj.put("lastModifiedDate", fp.lastModified());
+            obj.put("size", fp.length());
+        } catch (JSONException e) {
+            // this will never happen
+            e.printStackTrace();
+        }
+        return obj;
+    }
+
+    /**
+     * Creates a JSONObject that represents a File from the Uri
+     *
+     * @param path the absolute path saved in FileProvider of the audio/image/video
+     * @return a JSONObject that represents a File
+     * @throws IOException
+     */
+    private JSONObject createMediaFileWithAbsolutePath(String path) {
+        File fp = new File(path);
+        JSONObject obj = new JSONObject();
+
+        Class webViewClass = webView.getClass();
+        PluginManager pm = null;
+        try {
+            Method gpm = webViewClass.getMethod("getPluginManager");
+            pm = (PluginManager) gpm.invoke(webView);
+        } catch (NoSuchMethodException e) {
+        } catch (IllegalAccessException e) {
+        } catch (InvocationTargetException e) {
+        }
+        if (pm == null) {
+            try {
+                Field pmf = webViewClass.getField("pluginManager");
+                pm = (PluginManager)pmf.get(webView);
+            } catch (NoSuchFieldException e) {
+            } catch (IllegalAccessException e) {
+            }
+        }
+        FileUtils filePlugin = (FileUtils) pm.getPlugin("File");
+        LocalFilesystemURL url = filePlugin.filesystemURLforLocalPath(fp.getAbsolutePath());
+
+        try {
+            // File properties
+            obj.put("name", fp.getName());
+            obj.put("fullPath", Uri.fromFile(fp));
+            if (url != null) {
+                obj.put("localURL", url.toString());
+            }
+            // Because of an issue with MimeTypeMap.getMimeTypeFromExtension() all .3gpp files
+            // are reported as video/3gpp. I'm doing this hacky check of the URI to see if it
+            // is stored in the audio or video content store.
+            if (fp.getAbsoluteFile().toString().endsWith(".3gp") || fp.getAbsoluteFile().toString().endsWith(".3gpp")) {
+                obj.put("type", VIDEO_3GPP);
             } else {
                 obj.put("type", FileHelper.getMimeType(Uri.fromFile(fp), cordova));
             }

--- a/src/android/FileProvider.java
+++ b/src/android/FileProvider.java
@@ -1,0 +1,21 @@
+/*
+       Licensed to the Apache Software Foundation (ASF) under one
+       or more contributor license agreements.  See the NOTICE file
+       distributed with this work for additional information
+       regarding copyright ownership.  The ASF licenses this file
+       to you under the Apache License, Version 2.0 (the
+       "License"); you may not use this file except in compliance
+       with the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing,
+       software distributed under the License is distributed on an
+       "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+       KIND, either express or implied.  See the License for the
+       specific language governing permissions and limitations
+       under the License.
+*/
+package org.apache.cordova.mediacapture;
+
+public class FileProvider extends android.support.v4.content.FileProvider {}

--- a/src/android/FileProvider.java
+++ b/src/android/FileProvider.java
@@ -18,4 +18,4 @@
 */
 package org.apache.cordova.mediacapture;
 
-public class FileProvider extends android.support.v4.content.FileProvider {}
+public class FileProvider extends androidx.core.content.FileProvider {}

--- a/src/android/FileProvider.java
+++ b/src/android/FileProvider.java
@@ -18,4 +18,4 @@
 */
 package org.apache.cordova.mediacapture;
 
-public class FileProvider extends androidx.core.content.FileProvider {}
+public class FileProvider extends android.support.v4.content.FileProvider {}

--- a/src/android/FileProvider.java
+++ b/src/android/FileProvider.java
@@ -17,6 +17,5 @@
        under the License.
 */
 package org.apache.cordova.mediacapture;
-import androidx.core.content.FileProvider;
 
-public class FileProvider extends FileProvider {}
+public class FileProvider extends androidx.core.content.FileProvider {}

--- a/src/android/FileProvider.java
+++ b/src/android/FileProvider.java
@@ -17,5 +17,6 @@
        under the License.
 */
 package org.apache.cordova.mediacapture;
+import androidx.core.content.FileProvider;
 
-public class FileProvider extends android.support.v4.content.FileProvider {}
+public class FileProvider extends FileProvider {}

--- a/src/android/xml/mediacapture_provider_paths.xml
+++ b/src/android/xml/mediacapture_provider_paths.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <cache-path name="cache_files" path="." />
+</paths>


### PR DESCRIPTION
### Android


### Motivation and Context
Since the [Storage updates](https://developer.android.com/about/versions/11/privacy/storage) in Android 11, it would be impossible for app to get access to files (image, audio, video) saved into MediaStore external storage, as how it is implemented now. Starting from 2021 August, Android apps are required to target Android API level 30 (Android 11), which means it is critical that we need a new way to store files for media-capture plugin. More details are included in the issue #210.
Here is a suggested implementation for the above issue.

### Description
The idea is to use a ContentProvider (a [FileProvider](https://developer.android.com/reference/androidx/core/content/FileProvider), in this case) as a common database to store files, so that both our app and other apps can get access to. 
An empty file (audio, image, video) with unique file name (which is generated using current timestamp) and corresponding file format will be created before capturing. Unique file name prevents the file from being duplicated. We use FileProvider to create a Uri for the file, and send it through capturing intents as [`EXTRA_OUTPUT`](https://developer.android.com/reference/android/provider/MediaStore#EXTRA_OUTPUT), so that the created file will be saved with the above Uri.  Meanwhile, we store the file absolute path as a global variable, so that it can be used when the intent returns results.
As the file is saved into FileProvider, the app will get access and have control over the created file. 

### Testing
captureAudio, captureImage, captureVideo features are tested over various Android devices (from Android 7 to Android 11 are covered) using [browserstack](https://www.browserstack.com/) app live. The app then has full access over the generated media file (move, delete, transcode, etc).

### Checklist

- [x]  I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
