### PR TITLE
[iOS] add saveToGallery param on iOS for captureVideo

### DIFF
--- a/src/ios/CDVCapture.h
+++ b/src/ios/CDVCapture.h
@@ -49,8 +49,10 @@ typedef NSUInteger CDVCaptureError;
 {
     CDVImagePicker* pickerController;
     BOOL inUse;
+    BOOL saveToGallery;
 }
 @property BOOL inUse;
+@property BOOL saveToGallery;
 - (void)captureAudio:(CDVInvokedUrlCommand*)command;
 - (void)captureImage:(CDVInvokedUrlCommand*)command;
 - (CDVPluginResult*)processImage:(UIImage*)image type:(NSString*)mimeType forCallbackId:(NSString*)callbackId;

--- a/src/ios/CDVCapture.m
+++ b/src/ios/CDVCapture.m
@@ -76,6 +76,7 @@
 
 @implementation CDVCapture
 @synthesize inUse;
+@synthesize saveToGallery;
 
 - (void)pluginInitialize
 {
@@ -220,6 +221,14 @@
         options = [NSDictionary dictionary];
     }
 
+    // option to save video to gallery or not
+    NSNumber* saveToGallery = [options objectForKey:@"saveToGallery"];
+    if([saveToGallery intValue] == 1) {
+        self.saveToGallery = YES;
+    } else {
+        self.saveToGallery = NO;
+    }
+
     // options could contain limit, duration and mode
     // taking more than one video (limit) is only supported if provide own controls via cameraOverlayView property
     NSNumber* duration = [options objectForKey:@"duration"];
@@ -280,14 +289,15 @@
 - (CDVPluginResult*)processVideo:(NSString*)moviePath forCallbackId:(NSString*)callbackId
 {
     // save the movie to photo album (only avail as of iOS 3.1)
-
-    /* don't need, it should automatically get saved
-     NSLog(@"can save %@: %d ?", moviePath, UIVideoAtPathIsCompatibleWithSavedPhotosAlbum(moviePath));
-    if (&UIVideoAtPathIsCompatibleWithSavedPhotosAlbum != NULL && UIVideoAtPathIsCompatibleWithSavedPhotosAlbum(moviePath) == YES) {
-        NSLog(@"try to save movie");
-        UISaveVideoAtPathToSavedPhotosAlbum(moviePath, nil, nil, nil);
-        NSLog(@"finished saving movie");
-    }*/
+    if(self.saveToGallery == YES) {
+        NSLog(@"can save %@: %d ?", moviePath, UIVideoAtPathIsCompatibleWithSavedPhotosAlbum(moviePath));
+        if (&UIVideoAtPathIsCompatibleWithSavedPhotosAlbum != NULL && UIVideoAtPathIsCompatibleWithSavedPhotosAlbum(moviePath) == YES) {
+            NSLog(@"try to save movie");
+            UISaveVideoAtPathToSavedPhotosAlbum(moviePath, nil, nil, nil);
+            NSLog(@"finished saving movie");
+        }
+    }
+     
     // create MediaFile object
     NSDictionary* fileDict = [self getMediaDictionaryFromPath:moviePath ofType:nil];
     NSArray* fileArray = [NSArray arrayWithObject:fileDict];


### PR DESCRIPTION


### iOS



### Motivation and Context
Currently, the plugin saves the video file into gallery by default, which is not an expected behaviour in many cases. Developers should have the control over whether the file should be saved into gallery or not.
The issue for this is described in #216 



### Description
A new param `saveToGallery` is added. We get the input configuration in `captureVideo`, and set it to a global variable. It will be used in `processVideo` method to decide whether the file should be saved into gallery or not.



### Testing
set `saveToGallery` param to 0 and 1 when capturing video, seeing whether the file is saved into gallery. Make sure it works as intended.



### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
