### PR TITLE
fix(android): prevent app crash caused by NPE on intent data or mediaFile

### DIFF
--- a/src/android/Capture.java
+++ b/src/android/Capture.java
@@ -285,17 +285,6 @@ public class Capture extends CordovaPlugin {
         }
     }
 
-    private String getTempDirectoryPath() {
-        File cache = null;
-
-        // Use internal storage
-        cache = cordova.getActivity().getCacheDir();
-
-        // Create the cache directory if it doesn't exist
-        cache.mkdirs();
-        return cache.getAbsolutePath();
-    }
-
     /**
      * Sets up an intent to capture images.  Result handled by onActivityResult()
      */
@@ -427,17 +416,8 @@ public class Capture extends CordovaPlugin {
     }
 
     public void onVideoActivityResult(Request req, Intent intent) {
-        Uri data = null;
-
-        if (intent != null){
-            // Get the uri of the video clip
-            data = intent.getData();
-        }
-
-        if( data == null){
-            File movie = new File(getTempDirectoryPath(), "Capture.avi");
-            data = Uri.fromFile(movie);
-        }
+        // Get the uri of the video clip
+        Uri data = intent.getData();
 
         // create a file object from the uri
         if(data == null) {

--- a/src/android/Capture.java
+++ b/src/android/Capture.java
@@ -20,24 +20,19 @@ package org.apache.cordova.mediacapture;
 
 import java.io.File;
 import java.io.IOException;
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
-
-import android.content.ActivityNotFoundException;
-import android.os.Build;
-import android.os.Bundle;
-
-import org.apache.cordova.file.FileUtils;
-import org.apache.cordova.file.LocalFilesystemURL;
 
 import org.apache.cordova.CallbackContext;
 import org.apache.cordova.CordovaPlugin;
 import org.apache.cordova.LOG;
 import org.apache.cordova.PermissionHelper;
 import org.apache.cordova.PluginManager;
+import org.apache.cordova.file.FileUtils;
+import org.apache.cordova.file.LocalFilesystemURL;
 import org.apache.cordova.mediacapture.PendingRequests.Request;
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -45,6 +40,7 @@ import org.json.JSONObject;
 
 import android.Manifest;
 import android.app.Activity;
+import android.content.ActivityNotFoundException;
 import android.content.ContentResolver;
 import android.content.ContentValues;
 import android.content.Intent;
@@ -54,6 +50,8 @@ import android.database.Cursor;
 import android.graphics.BitmapFactory;
 import android.media.MediaPlayer;
 import android.net.Uri;
+import android.os.Build;
+import android.os.Bundle;
 import android.os.Environment;
 import android.provider.MediaStore;
 
@@ -305,11 +303,6 @@ public class Capture extends CordovaPlugin {
         intent.putExtra(android.provider.MediaStore.EXTRA_OUTPUT, imageUri);
 
         this.cordova.startActivityForResult((CordovaPlugin) this, intent, req.requestCode);
-    }
-
-    private static void createWritableFile(File file) throws IOException {
-        file.createNewFile();
-        file.setWritable(true, false);
     }
 
     /**


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Prevent app crash after capture and show error if no content or no access to it


### Description
<!-- Describe your changes in detail -->
1. minimal fix #227 
Unify null checks for all three capture types, first on retrieved intent data uri (failing with `CAPTURE_NO_MEDIA_FILES`), and then on no mediaFile created (failing with `CAPTURE_INTERNAL_ERR`)
1. Simplify how video uri is retrieved from Video capture intent (see #210 comment)


### Testing
<!-- Please describe in detail how you tested your changes. -->
App crashing because of audio capture in some conditions (see #227 comment) now resolves with failure instead.
Not perfect, expecting #215 work on FileProvider to solve the problem but for now it is not an app crash anymore.


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
