### PR TITLE
test: remove cordova-plugin-media dependency

### DIFF
--- a/tests/plugin.xml
+++ b/tests/plugin.xml
@@ -26,8 +26,6 @@
     <name>Cordova Media Capture Plugin Tests</name>
     <license>Apache 2.0</license>
 
-    <dependency id="cordova-plugin-media" />
-
     <js-module src="tests.js" name="tests">
     </js-module>
 </plugin>


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

n/a

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Remove the `cordova-plugin-media` dependency from the test.

The plugin is not a dependency of the release package, so it may not be necessary for the test.

### Description
<!-- Describe your changes in detail -->

deleted `cordova-plugin-media` dependency

### Testing
<!-- Please describe in detail how you tested your changes. -->

n/a - check gh actions

### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
