### PR TITLE
ci(android): update java requirement for cordova-android@11

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -43,8 +43,8 @@ jobs:
 
       # These are the default Java configurations used by most tests.
       # To customize these options, add "java-distro" or "java-version" to the strategy matrix with its overriding value.
-      default_java-distro: adopt
-      default_java-version: 8
+      default_java-distro: temurin
+      default_java-version: 11
 
       # These are the default Android System Image configurations used by most tests.
       # To customize these options, add "system-image-arch" or "system-image-target" to the strategy matrix with its overriding value.
@@ -82,7 +82,6 @@ jobs:
 
           - android: 11
             android-api: 30
-            java-version: 11
 
     timeout-minutes: 60
 
@@ -91,7 +90,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: ${{ env.node-version }}
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v3
         env:
           java-version: ${{ matrix.versions.java-version == '' && env.default_java-version || matrix.versions.java-version }}
           java-distro: ${{ matrix.versions.java-distro == '' && env.default_java-distro || matrix.versions.java-distro }}


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

CI: Android

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Paramedic which fetches and uses the latest releases of the platform is now using Cordova-Android@11.0.0, which requires Java 11.

### Description
<!-- Describe your changes in detail -->

Update the GitHub Action workflow
 - Use latest version of the `actions/setup-java` GitHub Action plugin
 - Use Java 11
 - Use the Java Distro `temurin` which is the replacement of `adopt`

### Testing
<!-- Please describe in detail how you tested your changes. -->

- See Action

### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
