### PR TITLE
fix(ios): set category before creating AVAudioRecorder

### DIFF
--- a/src/ios/CDVCapture.m
+++ b/src/ios/CDVCapture.m
@@ -735,6 +735,8 @@
         }
     }
 
+    [self.avSession setCategory:AVAudioSessionCategoryPlayAndRecord error:&error];
+    
     // create file to record to in temporary dir
 
     NSString* docsPath = [NSTemporaryDirectory()stringByStandardizingPath];   // use file system temporary directory
@@ -793,7 +795,6 @@
         __weak CDVAudioRecorderViewController* weakSelf = self;
 
         void (^startRecording)(void) = ^{
-            [weakSelf.avSession setCategory:AVAudioSessionCategoryRecord error:&error];
             [weakSelf.avSession setActive:YES error:&error];
             if (error) {
                 // can't continue without active audio session


### PR DESCRIPTION
### Platforms affected

iOS

### Motivation and Context

Fixes #267

i.e. Recording audio doesn't work on iOS 6.2 or newer.

### Description

I changed setting category `AVAudioSessionCategoryPlayAndRecord` before creating `AVAudioRecorder`. 
This is according to the comment https://github.com/apache/cordova-plugin-media-capture/issues/267#issuecomment-1472150858 .

### Testing

In my local environment, I tested by creating cordova sample project and confirm the recording method (`navigator.device.capture.captureAudio`) works well on following devices.

iPhone SE 2th  iOS 16.4.1 (a)
iPhone 12  iOS 15.0
iPad Air 4th   iOS 16.3.1


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
