### PR TITLE
fix(ios): CAPTURE_APPLICATION_BUSY error when dismissing modal by swipe

### DIFF
--- a/src/ios/CDVCapture.m
+++ b/src/ios/CDVCapture.m
@@ -613,7 +613,7 @@
 
 @end
 
-@interface CDVAudioRecorderViewController () {
+@interface CDVAudioRecorderViewController () <UIAdaptivePresentationControllerDelegate> {
     UIStatusBarStyle _previousStatusBarStyle;
 }
 @end
@@ -736,6 +736,9 @@
     [super viewDidLoad];
     UIAccessibilityPostNotification(UIAccessibilityScreenChangedNotification, nil);
     NSError* error = nil;
+
+    // Add delegate to catch the dismiss event
+    self.navigationController.presentationController.delegate = self;
 
     if (self.avSession == nil) {
         // create audio session
@@ -943,6 +946,10 @@
 
     NSLog(@"error recording audio");
     self.pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_IO_EXCEPTION messageToErrorObject:CAPTURE_INTERNAL_ERR];
+    [self dismissAudioView:nil];
+}
+
+- (void)presentationControllerDidDismiss:(UIPresentationController *)presentationController {
     [self dismissAudioView:nil];
 }
 


### PR DESCRIPTION
closes #186

This PR is a copy of #186 but rebased against the current the main branch to resolve conflicts. 

See #186 for more details.

I have already tested and approved the changes from #186.