### PR TITLE
fix(android): remove broad media permissions

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -78,9 +78,6 @@ xmlns:android="http://schemas.android.com/apk/res/android"
 
         <config-file target="AndroidManifest.xml" parent="/*">
             <uses-permission android:name="android.permission.RECORD_AUDIO" />
-            <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
-            <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
-            <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
             <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
             <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
         </config-file>

--- a/src/android/Capture.java
+++ b/src/android/Capture.java
@@ -236,8 +236,8 @@ public class Capture extends CordovaPlugin {
     }
 
     private boolean isMissingPermissions(Request req, List<String> permissions) {
-        ArrayList<String> missingPermissions = new ArrayList<>();
-        for (String permission: permissions) {
+        List<String> missingPermissions = new ArrayList<>();
+        for (String permission : permissions) {
             if (!PermissionHelper.hasPermission(this, permission)) {
                 missingPermissions.add(permission);
             }
@@ -256,7 +256,7 @@ public class Capture extends CordovaPlugin {
     }
 
     private boolean isMissingCameraPermissions(Request req) {
-        ArrayList<String> cameraPermissions = new ArrayList<>(Arrays.asList(storagePermissions));
+        List<String> cameraPermissions = new ArrayList<>(Arrays.asList(storagePermissions));
         if (cameraPermissionInManifest) {
             cameraPermissions.add(Manifest.permission.CAMERA);
         }

--- a/src/android/Capture.java
+++ b/src/android/Capture.java
@@ -25,6 +25,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 import org.apache.cordova.CallbackContext;
 import org.apache.cordova.CordovaPlugin;
@@ -234,7 +235,7 @@ public class Capture extends CordovaPlugin {
         return obj;
     }
 
-    private boolean isMissingPermissions(Request req, ArrayList<String> permissions) {
+    private boolean isMissingPermissions(Request req, List<String> permissions) {
         ArrayList<String> missingPermissions = new ArrayList<>();
         for (String permission: permissions) {
             if (!PermissionHelper.hasPermission(this, permission)) {
@@ -250,21 +251,14 @@ public class Capture extends CordovaPlugin {
         return isMissingPermissions;
     }
 
-    private boolean isMissingPermissions(Request req, String mediaPermission) {
-        ArrayList<String> permissions = new ArrayList<>(Arrays.asList(storagePermissions));
-        if (mediaPermission != null && android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            permissions.add(mediaPermission);
-        }
-        return isMissingPermissions(req, permissions);
+    private boolean isMissingPermissions(Request req) {
+        return isMissingPermissions(req, Arrays.asList(storagePermissions));
     }
 
-    private boolean isMissingCameraPermissions(Request req, String mediaPermission) {
+    private boolean isMissingCameraPermissions(Request req) {
         ArrayList<String> cameraPermissions = new ArrayList<>(Arrays.asList(storagePermissions));
         if (cameraPermissionInManifest) {
             cameraPermissions.add(Manifest.permission.CAMERA);
-        }
-        if (mediaPermission != null && android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            cameraPermissions.add(mediaPermission);
         }
         return isMissingPermissions(req, cameraPermissions);
     }
@@ -273,7 +267,7 @@ public class Capture extends CordovaPlugin {
      * Sets up an intent to capture audio.  Result handled by onActivityResult()
      */
     private void captureAudio(Request req) {
-        if (isMissingPermissions(req, Manifest.permission.READ_MEDIA_AUDIO)) return;
+        if (isMissingPermissions(req)) return;
 
         try {
             Intent intent = new Intent(android.provider.MediaStore.Audio.Media.RECORD_SOUND_ACTION);
@@ -287,7 +281,7 @@ public class Capture extends CordovaPlugin {
      * Sets up an intent to capture images.  Result handled by onActivityResult()
      */
     private void captureImage(Request req) {
-        if (isMissingCameraPermissions(req, Manifest.permission.READ_MEDIA_IMAGES)) return;
+        if (isMissingCameraPermissions(req)) return;
 
         // Save the number of images currently on disk for later
         this.numPics = queryImgDB(whichContentStore()).getCount();
@@ -309,7 +303,7 @@ public class Capture extends CordovaPlugin {
      * Sets up an intent to capture video.  Result handled by onActivityResult()
      */
     private void captureVideo(Request req) {
-        if (isMissingCameraPermissions(req, Manifest.permission.READ_MEDIA_VIDEO)) return;
+        if (isMissingCameraPermissions(req)) return;
 
         Intent intent = new Intent(android.provider.MediaStore.ACTION_VIDEO_CAPTURE);
 


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android


### Motivation and Context
As discussed on #288, broad media permissions (`READ_MEDIA_IMAGES`, `READ_MEDIA_VIDEO`, `READ_MEDIA_AUDIO`) policy will be enforced on August 31, 2024, threatening the Google Play approval of apps using this plugin.

> For a more privacy preserving experience for users, we’re introducing the [Photo and Video Permissions policy](https://support.google.com/googleplay/android-developer/answer/13986130) to reduce the number of apps permitted to request broad photo/video permissions ([READ_MEDIA_IMAGES](https://developer.android.com/reference/android/Manifest.permission#READ_MEDIA_IMAGES) and [READ_MEDIA_VIDEO](https://developer.android.com/reference/android/Manifest.permission#READ_MEDIA_VIDEO)). Apps may only access photos and videos for purposes directly related to app functionality. Apps that have a one-time or infrequent need to access these files are requested to use a system picker, such as the Android [photo picker](https://developer.android.com/training/data-storage/shared/photopicker).

> Apps that request access to the READ_MEDIA_VIDEO or READ_MEDIA_IMAGES permission must successfully demonstrate a core use case that requires persistent or frequent need of photo/video access located in shared storage.

The purpose of this PR is to not use broad media permissions.

### Description
<!-- Describe your changes in detail -->
My understanding is that, we don't need these permissions in the first place.
I would be interested to know why the changes of #262 were considered necessary at the time, am I missing something?

Here are the requirements that I've gathered:

|Android Version|Requirement|Source|
|---|---|---|
|<= 9|`READ_EXTERNAL_STORAGE` and `WRITE_EXTERNAL_STORAGE` are needed to "access any media file"|https://developer.android.com/training/data-storage/shared/media?hl=en#extra-permissions|
|10|Same as Android 11+ (see below) BUT if the app has opted-out of scoped storage we still need the `EXTERNAL_STORAGE` permissions|https://developer.android.com/training/data-storage/use-cases?hl=en#running_on_android_10 https://developer.android.com/training/data-storage/use-cases?hl=en#opt-out-in-production-app|
|11+|There is no permission needed to perform a `MediaCapture` intent, save the media file to the `MediaStore.Images` collection and read it later because you "own" the file|https://developer.android.com/training/data-storage/shared/media?hl=en#storage-permission|

For Android 10, I would suggest this plugin be resilient to handle apps that have opted-out of scoped storage by using the `android:requestLegacyExternalStorage="true"` configuration.

With these information in mind, here is what I've changed:
- `READ_EXTERNAL_STORAGE` and `WRITE_EXTERNAL_STORAGE` declared in the manifest and asked at runtime only for Android up to 10
- Removal of `READ_MEDIA_IMAGES`, `READ_MEDIA_VIDEO`, `READ_MEDIA_AUDIO` from the manifest and runtime request.

### Testing
<!-- Please describe in detail how you tested your changes. -->

I have tested an image capture on Android 14, 13, 12L, 11, 10 and 9: the photo app opens, the file is well saved and can be read.

I there a documentation on how to run the unit-tests ?

### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
