### PR TITLE
Fix(android): save media capture to File Provider

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -76,6 +76,18 @@ xmlns:android="http://schemas.android.com/apk/res/android"
             </feature>
         </config-file>
 
+        <config-file target="AndroidManifest.xml" parent="application">
+            <provider
+                android:name="org.apache.cordova.mediacapture.FileProvider"
+                android:authorities="${applicationId}.cordova.plugin.mediacapture.provider"
+                android:exported="false"
+                android:grantUriPermissions="true" >
+                <meta-data
+                    android:name="android.support.FILE_PROVIDER_PATHS"
+                    android:resource="@xml/mediacapture_provider_paths"/>
+            </provider>
+        </config-file>
+
         <config-file target="AndroidManifest.xml" parent="/*">
             <uses-permission android:name="android.permission.RECORD_AUDIO" />
             <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
@@ -85,6 +97,8 @@ xmlns:android="http://schemas.android.com/apk/res/android"
         <source-file src="src/android/Capture.java" target-dir="src/org/apache/cordova/mediacapture" />
         <source-file src="src/android/FileHelper.java" target-dir="src/org/apache/cordova/mediacapture" />
         <source-file src="src/android/PendingRequests.java" target-dir="src/org/apache/cordova/mediacapture" />
+        <source-file src="src/android/FileProvider.java" target-dir="src/org/apache/cordova/mediacapture" />
+        <source-file src="src/android/res/xml/mediacapture_provider_paths.xml" target-dir="res/xml" />
 
         <js-module src="www/android/init.js" name="init">
             <runs />

--- a/src/android/Capture.java
+++ b/src/android/Capture.java
@@ -258,10 +258,7 @@ public class Capture extends CordovaPlugin {
     }
 
     private String getTempDirectoryPath() {
-        File cache = null;
-
-        // Use internal storage
-        cache = cordova.getActivity().getCacheDir();
+        File cache = new File(cordova.getActivity().getCacheDir(), "org.apache.cordova.mediacapture");
 
         // Create the cache directory if it doesn't exist
         cache.mkdirs();

--- a/src/android/Capture.java
+++ b/src/android/Capture.java
@@ -23,9 +23,11 @@ import java.io.IOException;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Date;
 
 import org.apache.cordova.CallbackContext;
 import org.apache.cordova.CordovaPlugin;
@@ -93,15 +95,11 @@ public class Capture extends CordovaPlugin {
     private final PendingRequests pendingRequests = new PendingRequests();
 
     private int numPics;                            // Number of pictures before capture activity
-    private Uri imageUri;
+    private String audioAbsolutePath;
+    private String imageAbsolutePath;
+    private String videoAbsolutePath;
 
-//    public void setContext(Context mCtx)
-//    {
-//        if (CordovaInterface.class.isInstance(mCtx))
-//            cordova = (CordovaInterface) mCtx;
-//        else
-//            LOG.d(LOG_TAG, "ERROR: You must use the CordovaInterface for this to work correctly. Please implement it in your activity");
-//    }
+    private String applicationId;
 
     @Override
     protected void pluginInitialize() {
@@ -132,6 +130,8 @@ public class Capture extends CordovaPlugin {
 
     @Override
     public boolean execute(String action, JSONArray args, CallbackContext callbackContext) throws JSONException {
+        this.applicationId = cordova.getContext().getPackageName();
+
         if (action.equals("getFormatData")) {
             JSONObject obj = getFormatData(args.getString(0), args.getString(1));
             callbackContext.success(obj);
@@ -142,14 +142,11 @@ public class Capture extends CordovaPlugin {
 
         if (action.equals("captureAudio")) {
             this.captureAudio(pendingRequests.createRequest(CAPTURE_AUDIO, options, callbackContext));
-        }
-        else if (action.equals("captureImage")) {
+        } else if (action.equals("captureImage")) {
             this.captureImage(pendingRequests.createRequest(CAPTURE_IMAGE, options, callbackContext));
-        }
-        else if (action.equals("captureVideo")) {
+        } else if (action.equals("captureVideo")) {
             this.captureVideo(pendingRequests.createRequest(CAPTURE_VIDEO, options, callbackContext));
-        }
-        else {
+        } else {
             return false;
         }
 
@@ -175,18 +172,16 @@ public class Capture extends CordovaPlugin {
 
         // If the mimeType isn't set the rest will fail
         // so let's see if we can determine it.
-        if (mimeType == null || mimeType.equals("") || "null".equals(mimeType)) {
+        if (mimeType == null || mimeType.isEmpty() || "null".equals(mimeType)) {
             mimeType = FileHelper.getMimeType(fileUrl, cordova);
         }
         LOG.d(LOG_TAG, "Mime type = " + mimeType);
 
         if (mimeType.equals(IMAGE_JPEG) || filePath.endsWith(".jpg")) {
             obj = getImageData(fileUrl, obj);
-        }
-        else if (Arrays.asList(AUDIO_TYPES).contains(mimeType)) {
+        } else if (Arrays.asList(AUDIO_TYPES).contains(mimeType)) {
             obj = getAudioVideoData(filePath, obj, false);
-        }
-        else if (mimeType.equals(VIDEO_3GPP) || mimeType.equals(VIDEO_MP4)) {
+        } else if (mimeType.equals(VIDEO_3GPP) || mimeType.equals(VIDEO_MP4)) {
             obj = getAudioVideoData(filePath, obj, true);
         }
         return obj;
@@ -242,7 +237,7 @@ public class Capture extends CordovaPlugin {
             }
         }
 
-        boolean isMissingPermissions = missingPermissions.size() > 0;
+        boolean isMissingPermissions = !missingPermissions.isEmpty();
         if (isMissingPermissions) {
             String[] missing = missingPermissions.toArray(new String[missingPermissions.size()]);
             PermissionHelper.requestPermissions(this, req.requestCode, missing);
@@ -262,6 +257,17 @@ public class Capture extends CordovaPlugin {
         return isMissingPermissions(req, cameraPermissions);
     }
 
+    private String getTempDirectoryPath() {
+        File cache = null;
+
+        // Use internal storage
+        cache = cordova.getActivity().getCacheDir();
+
+        // Create the cache directory if it doesn't exist
+        cache.mkdirs();
+        return cache.getAbsolutePath();
+    }
+
     /**
      * Sets up an intent to capture audio.  Result handled by onActivityResult()
      */
@@ -270,6 +276,16 @@ public class Capture extends CordovaPlugin {
 
         try {
             Intent intent = new Intent(android.provider.MediaStore.Audio.Media.RECORD_SOUND_ACTION);
+            String timeStamp = new SimpleDateFormat("yyyyMMddHHmmssSSS").format(new Date());
+            String fileName = "cdv_media_capture_audio_" + timeStamp + ".m4a";
+            File audio = new File(getTempDirectoryPath(), fileName);
+            Uri audioUri = FileProvider.getUriForFile(this.cordova.getActivity(),
+                    this.applicationId + ".cordova.plugin.mediacapture.provider",
+                    audio);
+            this.audioAbsolutePath = audio.getAbsolutePath();
+            intent.putExtra(android.provider.MediaStore.EXTRA_OUTPUT, audioUri);
+            LOG.d(LOG_TAG, "Recording an audio and saving to: " + this.audioAbsolutePath);
+
             this.cordova.startActivityForResult((CordovaPlugin) this, intent, req.requestCode);
         } catch (ActivityNotFoundException ex) {
             pendingRequests.resolveWithFailure(req, createErrorObject(CAPTURE_NOT_SUPPORTED, "No Activity found to handle Audio Capture."));
@@ -287,11 +303,16 @@ public class Capture extends CordovaPlugin {
 
         Intent intent = new Intent(android.provider.MediaStore.ACTION_IMAGE_CAPTURE);
 
-        ContentResolver contentResolver = this.cordova.getActivity().getContentResolver();
-        ContentValues cv = new ContentValues();
-        cv.put(MediaStore.Images.Media.MIME_TYPE, IMAGE_JPEG);
-        imageUri = contentResolver.insert(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, cv);
-        LOG.d(LOG_TAG, "Taking a picture and saving to: " + imageUri.toString());
+        String timeStamp = new SimpleDateFormat("yyyyMMddHHmmssSSS").format(new Date());
+        String fileName = "cdv_media_capture_image_" + timeStamp + ".jpg";
+        File image = new File(getTempDirectoryPath(), fileName);
+
+        Uri imageUri = FileProvider.getUriForFile(this.cordova.getActivity(),
+                this.applicationId + ".cordova.plugin.mediacapture.provider",
+                image);
+        this.imageAbsolutePath = image.getAbsolutePath();
+        intent.putExtra(android.provider.MediaStore.EXTRA_OUTPUT, imageUri);
+        LOG.d(LOG_TAG, "Taking a picture and saving to: " + this.imageAbsolutePath);
 
         intent.putExtra(android.provider.MediaStore.EXTRA_OUTPUT, imageUri);
 
@@ -305,6 +326,16 @@ public class Capture extends CordovaPlugin {
         if (isMissingCameraPermissions(req)) return;
 
         Intent intent = new Intent(android.provider.MediaStore.ACTION_VIDEO_CAPTURE);
+        String timeStamp = new SimpleDateFormat("yyyyMMddHHmmssSSS").format(new Date());
+        String fileName = "cdv_media_capture_video_" + timeStamp + ".mp4";
+        File movie = new File(getTempDirectoryPath(), fileName);
+
+        Uri videoUri = FileProvider.getUriForFile(this.cordova.getActivity(),
+                this.applicationId + ".cordova.plugin.mediacapture.provider",
+                movie);
+        this.videoAbsolutePath = movie.getAbsolutePath();
+        intent.putExtra(android.provider.MediaStore.EXTRA_OUTPUT, videoUri);
+        LOG.d(LOG_TAG, "Recording a video and saving to: " + this.videoAbsolutePath);
 
         if(Build.VERSION.SDK_INT > 7){
             intent.putExtra("android.intent.extra.durationLimit", req.duration);
@@ -332,13 +363,13 @@ public class Capture extends CordovaPlugin {
                 public void run() {
                     switch(req.action) {
                         case CAPTURE_AUDIO:
-                            onAudioActivityResult(req, intent);
+                            onAudioActivityResult(req);
                             break;
                         case CAPTURE_IMAGE:
                             onImageActivityResult(req);
                             break;
                         case CAPTURE_VIDEO:
-                            onVideoActivityResult(req, intent);
+                            onVideoActivityResult(req);
                             break;
                     }
                 }
@@ -371,18 +402,11 @@ public class Capture extends CordovaPlugin {
     }
 
 
-    public void onAudioActivityResult(Request req, Intent intent) {
-        // Get the uri of the audio clip
-        Uri data = intent.getData();
-        if (data == null) {
-            pendingRequests.resolveWithFailure(req, createErrorObject(CAPTURE_NO_MEDIA_FILES, "Error: data is null"));
-            return;
-        }
-
-        // Create a file object from the uri
-        JSONObject mediaFile = createMediaFile(data);
+    public void onAudioActivityResult(Request req) {
+        // create a file object from the audio absolute path
+        JSONObject mediaFile = createMediaFileWithAbsolutePath(this.audioAbsolutePath);
         if (mediaFile == null) {
-            pendingRequests.resolveWithFailure(req, createErrorObject(CAPTURE_INTERNAL_ERR, "Error: no mediaFile created from " + data));
+            pendingRequests.resolveWithFailure(req, createErrorObject(CAPTURE_INTERNAL_ERR, "Error: no mediaFile created from " + this.audioAbsolutePath));
             return;
         }
 
@@ -398,17 +422,10 @@ public class Capture extends CordovaPlugin {
     }
 
     public void onImageActivityResult(Request req) {
-        // Get the uri of the image
-        Uri data = imageUri;
-        if (data == null) {
-            pendingRequests.resolveWithFailure(req, createErrorObject(CAPTURE_NO_MEDIA_FILES, "Error: data is null"));
-            return;
-        }
-
-        // Create a file object from the uri
-        JSONObject mediaFile = createMediaFile(data);
+        // create a file object from the image absolute path
+        JSONObject mediaFile = createMediaFileWithAbsolutePath(this.imageAbsolutePath);
         if (mediaFile == null) {
-            pendingRequests.resolveWithFailure(req, createErrorObject(CAPTURE_INTERNAL_ERR, "Error: no mediaFile created from " + data));
+            pendingRequests.resolveWithFailure(req, createErrorObject(CAPTURE_INTERNAL_ERR, "Error: no mediaFile created from " + this.imageAbsolutePath));
             return;
         }
 
@@ -425,18 +442,11 @@ public class Capture extends CordovaPlugin {
         }
     }
 
-    public void onVideoActivityResult(Request req, Intent intent) {
-        // Get the uri of the video clip
-        Uri data = intent.getData();
-        if (data == null) {
-            pendingRequests.resolveWithFailure(req, createErrorObject(CAPTURE_NO_MEDIA_FILES, "Error: data is null"));
-            return;
-        }
-
-        // Create a file object from the uri
-        JSONObject mediaFile = createMediaFile(data);
+    public void onVideoActivityResult(Request req) {
+        // create a file object from the video absolute path
+        JSONObject mediaFile = createMediaFileWithAbsolutePath(this.videoAbsolutePath);
         if (mediaFile == null) {
-            pendingRequests.resolveWithFailure(req, createErrorObject(CAPTURE_INTERNAL_ERR, "Error: no mediaFile created from " + data));
+            pendingRequests.resolveWithFailure(req, createErrorObject(CAPTURE_INTERNAL_ERR, "Error: no mediaFile created from " + this.videoAbsolutePath));
             return;
         }
 
@@ -452,18 +462,14 @@ public class Capture extends CordovaPlugin {
     }
 
     /**
-     * Creates a JSONObject that represents a File from the Uri
+     * Creates a JSONObject that represents a File from the absolute path
      *
-     * @param data the Uri of the audio/image/video
+     * @param path the absolute path saved in FileProvider of the audio/image/video
      * @return a JSONObject that represents a File
      * @throws IOException
      */
-    private JSONObject createMediaFile(Uri data) {
-        File fp = webView.getResourceApi().mapUriToFile(data);
-        if (fp == null) {
-            return null;
-        }
-
+    private JSONObject createMediaFileWithAbsolutePath(String path) {
+        File fp = new File(path);
         JSONObject obj = new JSONObject();
 
         Class webViewClass = webView.getClass();
@@ -471,16 +477,15 @@ public class Capture extends CordovaPlugin {
         try {
             Method gpm = webViewClass.getMethod("getPluginManager");
             pm = (PluginManager) gpm.invoke(webView);
-        } catch (NoSuchMethodException e) {
-        } catch (IllegalAccessException e) {
-        } catch (InvocationTargetException e) {
+        } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+            // Do Nothing
         }
         if (pm == null) {
             try {
                 Field pmf = webViewClass.getField("pluginManager");
                 pm = (PluginManager)pmf.get(webView);
-            } catch (NoSuchFieldException e) {
-            } catch (IllegalAccessException e) {
+            } catch (NoSuchFieldException | IllegalAccessException e) {
+                // Do Nothing
             }
         }
         FileUtils filePlugin = (FileUtils) pm.getPlugin("File");
@@ -497,6 +502,7 @@ public class Capture extends CordovaPlugin {
             // are reported as video/3gpp. I'm doing this hacky check of the URI to see if it
             // is stored in the audio or video content store.
             if (fp.getAbsoluteFile().toString().endsWith(".3gp") || fp.getAbsoluteFile().toString().endsWith(".3gpp")) {
+                Uri data = Uri.fromFile(fp);
                 if (data.toString().contains("/audio/")) {
                     obj.put("type", AUDIO_3GPP);
                 } else {

--- a/src/android/FileProvider.java
+++ b/src/android/FileProvider.java
@@ -1,0 +1,20 @@
+/*
+       Licensed to the Apache Software Foundation (ASF) under one
+       or more contributor license agreements.  See the NOTICE file
+       distributed with this work for additional information
+       regarding copyright ownership.  The ASF licenses this file
+       to you under the Apache License, Version 2.0 (the
+       "License"); you may not use this file except in compliance
+       with the License.  You may obtain a copy of the License at
+         http://www.apache.org/licenses/LICENSE-2.0
+       Unless required by applicable law or agreed to in writing,
+       software distributed under the License is distributed on an
+       "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+       KIND, either express or implied.  See the License for the
+       specific language governing permissions and limitations
+       under the License.
+*/
+package org.apache.cordova.mediacapture;
+
+public class FileProvider extends androidx.core.content.FileProvider {
+}

--- a/src/android/res/xml/mediacapture_provider_paths.xml
+++ b/src/android/res/xml/mediacapture_provider_paths.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <cache-path name="cache_files" path="." />
+</paths>

--- a/src/android/res/xml/mediacapture_provider_paths.xml
+++ b/src/android/res/xml/mediacapture_provider_paths.xml
@@ -17,5 +17,5 @@
 -->
 
 <paths xmlns:android="http://schemas.android.com/apk/res/android">
-    <cache-path name="cache_files" path="." />
+    <cache-path name="cache_files" path="org.apache.cordova.mediacapture" />
 </paths>


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

Android

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
In an app that I develop, the captured file needs to be moved to a specific app directory. In current plugin version, it works for most Android overlays versions, but for some, it does not (#289, #286, #233, #277, #221, #196 and #210) due to Android's limitation to use external files.
The PR [!215 ](https://github.com/apache/cordova-plugin-media-capture/pull/215) did exactly the job I needed, so I just retrieved @chriskhongqarma's changes and applied them to current master branch with suggestions.


### Description
<!-- Describe your changes in detail -->
The idea is to use a ContentProvider (a [FileProvider](https://developer.android.com/reference/androidx/core/content/FileProvider), in this case) as a common database to store files, so that both our app and other apps can get access to.
An empty file (audio, image, video) with unique file name (which is generated using current timestamp) and corresponding file format will be created before capturing. Unique file name prevents the file from being duplicated. We use FileProvider to create a Uri for the file, and send it through capturing intents as [EXTRA_OUTPUT](https://developer.android.com/reference/android/provider/MediaStore#EXTRA_OUTPUT), so that the created file will be saved with the above Uri. Meanwhile, we store the file absolute path as a global variable, so that it can be used when the intent returns results.
As the file is saved into FileProvider, the app will get access and have control over the created file.


### Testing
<!-- Please describe in detail how you tested your changes. -->
captureAudio, captureImage, captureVideo features are tested over various Android devices (from Android 10 to Android 14 are covered) using [browserstack](https://www.browserstack.com/) app live. The app then has full access over the generated media file (move, delete, transcode, etc).


### Checklist

- [X] I've run the tests to see all new and existing tests pass
- [X] I added automated test coverage as appropriate for this change
- [X] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [X] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [X] I've updated the documentation if necessary
