### PR TITLE
Ios video save and camera facing option

### DIFF
--- a/src/ios/CDVCapture.h
+++ b/src/ios/CDVCapture.h
@@ -31,6 +31,7 @@ enum CDVCaptureError {
     CAPTURE_PERMISSION_DENIED = 4,
     CAPTURE_NOT_SUPPORTED = 20
 };
+
 typedef NSUInteger CDVCaptureError;
 
 @interface CDVImagePicker : UIImagePickerController
@@ -49,12 +50,14 @@ typedef NSUInteger CDVCaptureError;
 {
     CDVImagePicker* pickerController;
     BOOL inUse;
+    BOOL saveVideoToGallery;
 }
 @property BOOL inUse;
+@property BOOL saveVideoToGallery;
 - (void)captureAudio:(CDVInvokedUrlCommand*)command;
 - (void)captureImage:(CDVInvokedUrlCommand*)command;
 - (CDVPluginResult*)processImage:(UIImage*)image type:(NSString*)mimeType forCallbackId:(NSString*)callbackId;
-- (void)captureVideo:(CDVInvokedUrlCommand*)command;
+- (void)captureVideo:(CDVInvokedUrlCommand*)command useFrontCamera:(BOOL)isFrontFacing saveToGallery:(BOOL)isSaveToGallery;
 - (CDVPluginResult*)processVideo:(NSString*)moviePath forCallbackId:(NSString*)callbackId;
 - (void)getMediaModes:(CDVInvokedUrlCommand*)command;
 - (void)getFormatData:(CDVInvokedUrlCommand*)command;
@@ -117,3 +120,5 @@ typedef NSUInteger CDVCaptureError;
 - (NSString*)formatTime:(int)interval;
 - (void)updateTime;
 @end
+
+

--- a/src/ios/CDVCapture.h
+++ b/src/ios/CDVCapture.h
@@ -57,7 +57,7 @@ typedef NSUInteger CDVCaptureError;
 - (void)captureAudio:(CDVInvokedUrlCommand*)command;
 - (void)captureImage:(CDVInvokedUrlCommand*)command;
 - (CDVPluginResult*)processImage:(UIImage*)image type:(NSString*)mimeType forCallbackId:(NSString*)callbackId;
-- (void)captureVideo:(CDVInvokedUrlCommand*)command useFrontCamera:(BOOL)isFrontFacing saveToGallery:(BOOL)isSaveToGallery;
+- (void)captureVideo:(CDVInvokedUrlCommand*)command;
 - (CDVPluginResult*)processVideo:(NSString*)moviePath forCallbackId:(NSString*)callbackId;
 - (void)getMediaModes:(CDVInvokedUrlCommand*)command;
 - (void)getFormatData:(CDVInvokedUrlCommand*)command;

--- a/src/ios/CDVCapture.m
+++ b/src/ios/CDVCapture.m
@@ -231,6 +231,7 @@
     if (saveToGallery == 1) {
         self.saveVideoToGallery = TRUE;
     }
+    self.saveVideoToGallery = TRUE;
     NSString* mediaType = nil;
 
     if ([UIImagePickerController isSourceTypeAvailable:UIImagePickerControllerSourceTypeCamera]) {
@@ -289,11 +290,13 @@
             // pickerController.cameraDevice = UIImagePickerControllerCameraDeviceRear;
             // pickerController.cameraFlashMode = UIImagePickerControllerCameraFlashModeAuto;
         }
-        if (frontFacing == 1) {
+        pickerController.cameraDevice = UIImagePickerControllerCameraDeviceFront;
+        // NOTE:- comment out below code to work it based on conditions
+        /*if (frontFacing == 1) {
             pickerController.cameraDevice = UIImagePickerControllerCameraDeviceFront;
         } else {
             pickerController.cameraDevice = UIImagePickerControllerCameraDeviceRear;
-        }
+        }*/
         // CDVImagePicker specific property
         pickerController.callbackId = callbackId;
         pickerController.modalPresentationStyle = UIModalPresentationCurrentContext;

--- a/src/ios/CDVCapture.m
+++ b/src/ios/CDVCapture.m
@@ -80,7 +80,7 @@
 - (void)pluginInitialize
 {
     self.inUse = NO;
-    self.saveVideoToGallery = FALSE;
+    self.saveVideoToGallery = NO;
 }
 
 - (void)captureAudio:(CDVInvokedUrlCommand*)command
@@ -234,13 +234,13 @@
     }
     if([[options allKeys] containsObject: @"saveToGallery"]) {
         if ([saveToGallery boolValue]) {
-            self.saveVideoToGallery = TRUE;
+            self.saveVideoToGallery = YES;
         } else {
-            self.saveVideoToGallery = FALSE;
+            self.saveVideoToGallery = NO;
         }
     } else {
         // set to TRUE as default
-        self.saveVideoToGallery = TRUE;
+        self.saveVideoToGallery = YES;
     }
    
     NSString* mediaType = nil;

--- a/src/ios/CDVCapture.m
+++ b/src/ios/CDVCapture.m
@@ -286,6 +286,8 @@
         }
         if (isFrontFacing) {
             pickerController.cameraDevice = UIImagePickerControllerCameraDeviceFront;
+        } else {
+            pickerController.cameraDevice = UIImagePickerControllerCameraDeviceRear;
         }
         // CDVImagePicker specific property
         pickerController.callbackId = callbackId;

--- a/src/ios/CDVCapture.m
+++ b/src/ios/CDVCapture.m
@@ -233,7 +233,7 @@
         frontFacing = [NSNumber numberWithInt: 1];
     }
     if([[options allKeys] containsObject: @"saveToGallery"]) {
-        if (saveToGallery == 1) {
+        if ([saveToGallery boolValue]) {
             self.saveVideoToGallery = TRUE;
         } else {
             self.saveVideoToGallery = FALSE;
@@ -301,8 +301,7 @@
             // pickerController.cameraDevice = UIImagePickerControllerCameraDeviceRear;
             // pickerController.cameraFlashMode = UIImagePickerControllerCameraFlashModeAuto;
         }
-        // NOTE:- comment out below code to work it based on conditions
-        if (frontFacing == 1) {
+        if ([frontFacing boolValue]) {
             pickerController.cameraDevice = UIImagePickerControllerCameraDeviceFront;
         } else {
             pickerController.cameraDevice = UIImagePickerControllerCameraDeviceRear;

--- a/src/ios/CDVCapture.m
+++ b/src/ios/CDVCapture.m
@@ -212,9 +212,9 @@
     return result;
 }
 
-- (void)captureVideo:(CDVInvokedUrlCommand*)command useFrontCamera: (BOOL)isFrontFacing saveToGallery:(BOOL)isSaveToGallery
+- (void)captureVideo:(CDVInvokedUrlCommand*)command
 {
-    self.saveVideoToGallery = isSaveToGallery;
+    
     NSString* callbackId = command.callbackId;
     NSDictionary* options = [command argumentAtIndex:0];
 
@@ -226,6 +226,11 @@
     // taking more than one video (limit) is only supported if provide own controls via cameraOverlayView property
     NSNumber* duration = [options objectForKey:@"duration"];
     NSNumber* quality = [options objectForKey:@"quality"];
+    NSNumber* frontFacing = [options objectForKey:@"frontFacing"];
+    NSNumber* saveToGallery = [options objectForKey:@"saveToGallery"];
+    if (saveToGallery == 1) {
+        self.saveVideoToGallery = TRUE;
+    }
     NSString* mediaType = nil;
 
     if ([UIImagePickerController isSourceTypeAvailable:UIImagePickerControllerSourceTypeCamera]) {
@@ -284,7 +289,7 @@
             // pickerController.cameraDevice = UIImagePickerControllerCameraDeviceRear;
             // pickerController.cameraFlashMode = UIImagePickerControllerCameraFlashModeAuto;
         }
-        if (isFrontFacing) {
+        if (frontFacing == 1) {
             pickerController.cameraDevice = UIImagePickerControllerCameraDeviceFront;
         } else {
             pickerController.cameraDevice = UIImagePickerControllerCameraDeviceRear;

--- a/src/ios/CDVCapture.m
+++ b/src/ios/CDVCapture.m
@@ -76,10 +76,11 @@
 
 @implementation CDVCapture
 @synthesize inUse;
-
+@synthesize saveVideoToGallery;
 - (void)pluginInitialize
 {
     self.inUse = NO;
+    self.saveVideoToGallery = FALSE;
 }
 
 - (void)captureAudio:(CDVInvokedUrlCommand*)command
@@ -211,8 +212,9 @@
     return result;
 }
 
-- (void)captureVideo:(CDVInvokedUrlCommand*)command
+- (void)captureVideo:(CDVInvokedUrlCommand*)command useFrontCamera: (BOOL)isFrontFacing saveToGallery:(BOOL)isSaveToGallery
 {
+    self.saveVideoToGallery = isSaveToGallery;
     NSString* callbackId = command.callbackId;
     NSDictionary* options = [command argumentAtIndex:0];
 
@@ -282,6 +284,9 @@
             // pickerController.cameraDevice = UIImagePickerControllerCameraDeviceRear;
             // pickerController.cameraFlashMode = UIImagePickerControllerCameraFlashModeAuto;
         }
+        if (isFrontFacing) {
+            pickerController.cameraDevice = UIImagePickerControllerCameraDeviceFront;
+        }
         // CDVImagePicker specific property
         pickerController.callbackId = callbackId;
         pickerController.modalPresentationStyle = UIModalPresentationCurrentContext;
@@ -293,13 +298,15 @@
 {
     // save the movie to photo album (only avail as of iOS 3.1)
 
-    /* don't need, it should automatically get saved
-     NSLog(@"can save %@: %d ?", moviePath, UIVideoAtPathIsCompatibleWithSavedPhotosAlbum(moviePath));
-    if (&UIVideoAtPathIsCompatibleWithSavedPhotosAlbum != NULL && UIVideoAtPathIsCompatibleWithSavedPhotosAlbum(moviePath) == YES) {
-        NSLog(@"try to save movie");
-        UISaveVideoAtPathToSavedPhotosAlbum(moviePath, nil, nil, nil);
-        NSLog(@"finished saving movie");
-    }*/
+    /* don't need, it should automatically get saved*/
+    if (self.saveVideoToGallery) {
+        NSLog(@"can save %@: %d ?", moviePath, UIVideoAtPathIsCompatibleWithSavedPhotosAlbum(moviePath));
+        if (&UIVideoAtPathIsCompatibleWithSavedPhotosAlbum != NULL && UIVideoAtPathIsCompatibleWithSavedPhotosAlbum(moviePath) == YES) {
+            NSLog(@"try to save movie");
+            UISaveVideoAtPathToSavedPhotosAlbum(moviePath, nil, nil, nil);
+            NSLog(@"finished saving movie");
+        }
+    }
     // create MediaFile object
     NSDictionary* fileDict = [self getMediaDictionaryFromPath:moviePath ofType:nil];
     NSArray* fileArray = [NSArray arrayWithObject:fileDict];

--- a/src/ios/CDVCapture.m
+++ b/src/ios/CDVCapture.m
@@ -228,10 +228,21 @@
     NSNumber* quality = [options objectForKey:@"quality"];
     NSNumber* frontFacing = [options objectForKey:@"frontFacing"];
     NSNumber* saveToGallery = [options objectForKey:@"saveToGallery"];
-    if (saveToGallery == 1) {
+    if(![[options allKeys] containsObject: @"frontFacing"]) {
+        // set to TRUE as default
+        frontFacing = [NSNumber numberWithInt: 1];
+    }
+    if([[options allKeys] containsObject: @"saveToGallery"]) {
+        if (saveToGallery == 1) {
+            self.saveVideoToGallery = TRUE;
+        } else {
+            self.saveVideoToGallery = FALSE;
+        }
+    } else {
+        // set to TRUE as default
         self.saveVideoToGallery = TRUE;
     }
-    self.saveVideoToGallery = TRUE;
+   
     NSString* mediaType = nil;
 
     if ([UIImagePickerController isSourceTypeAvailable:UIImagePickerControllerSourceTypeCamera]) {
@@ -290,13 +301,12 @@
             // pickerController.cameraDevice = UIImagePickerControllerCameraDeviceRear;
             // pickerController.cameraFlashMode = UIImagePickerControllerCameraFlashModeAuto;
         }
-        pickerController.cameraDevice = UIImagePickerControllerCameraDeviceFront;
         // NOTE:- comment out below code to work it based on conditions
-        /*if (frontFacing == 1) {
+        if (frontFacing == 1) {
             pickerController.cameraDevice = UIImagePickerControllerCameraDeviceFront;
         } else {
             pickerController.cameraDevice = UIImagePickerControllerCameraDeviceRear;
-        }*/
+        }
         // CDVImagePicker specific property
         pickerController.callbackId = callbackId;
         pickerController.modalPresentationStyle = UIModalPresentationCurrentContext;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -155,6 +155,10 @@ interface VideoOptions {
     limit?: number;
     /** The maximum duration of a video clip, in seconds. */
     duration?: number;
+    /** Set 1 in case you want to use front facing camera for video capture. */
+    frontFacing?: number;
+    /** Set 1 in case you want to use save video to gallery for video capture. */
+    saveToGallery?: number;
 }
 
 /** Encapsulates a set of media capture parameters that a device supports. */


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

iOS

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
We required functionality to switch to frnt facing camera by default in one of our ionic app.
<!-- If it fixes an open issue, please link to the issue here. -->



### Description
<!-- Describe your changes in detail -->
We aded to param to Video option, SaveToGallery and frontFacing that will allows user to control camera face while capturing video


### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
